### PR TITLE
CR-001: Product modes and command model

### DIFF
--- a/docs/implementation-specs/CR-001-product-modes-and-command-model.md
+++ b/docs/implementation-specs/CR-001-product-modes-and-command-model.md
@@ -1,0 +1,56 @@
+# CR-001 Implementation Specification: Product Modes and Command Model
+
+## Scope
+
+This increment introduces explicit product modes at the command boundary while preserving the
+current validation pipeline and file selector implementation for later refactors.
+
+## Commands
+
+- `git-commit-code-check`
+  - Starts or attaches to the assistant daemon for the current repository.
+  - Successful startup is silent.
+  - Startup failures are printed to stderr and return a non-zero exit code.
+- `git-commit-code-check check`
+  - Runs an interactive one-shot validation.
+  - May invoke fix actions.
+  - Runs post actions after successful fixing.
+- `git-commit-code-check check --batch`
+  - Runs one-shot validation without invoking fix actions.
+  - Returns non-zero when HIGH diagnostics are present.
+- `git-commit-code-check pre-commit`
+  - Runs deterministic non-interactive validation.
+  - Does not invoke fix actions or post actions.
+  - Hides LOW diagnostics, prints MEDIUM and HIGH diagnostics, and blocks only on HIGH.
+- `git-commit-code-check status`
+  - Delegates status reporting to the assistant daemon boundary.
+- `git-commit-code-check fix`
+  - Provides an explicit user-triggered fix command boundary for later daemon-backed fixing.
+
+## Design
+
+- Picocli command classes stay thin and delegate to `CodeCheckCommandService`.
+- `CodeCheckCommandService` owns product-mode behavior, validation rendering, and exit-code
+  decisions.
+- `AssistantDaemonController` is the daemon boundary used by command modes. The CR-001
+  implementation delegates to the existing in-process daemon server; CR-003 will replace this
+  with start/attach metadata and WebSocket transport.
+- The validation engine is not replaced in this increment. `ValidationCheckPipeline` remains the
+  shared validation core until CR-005 extracts the structured engine.
+
+## Mode Policy
+
+| Mode | Fix actions | Printed diagnostics | Blocking diagnostics |
+| --- | --- | --- | --- |
+| Assistant daemon | none from CLI startup | daemon-owned | startup failure |
+| Interactive check | yes | LOW, MEDIUM, HIGH | remaining diagnostics unless `--no-exit-code` |
+| Batch check | no | LOW, MEDIUM, HIGH | HIGH |
+| Pre-commit | no | MEDIUM, HIGH | HIGH |
+
+## Tests
+
+- Bare command mode delegates to daemon start/attach and stays silent on success.
+- Daemon startup failures are clear and non-zero.
+- Batch mode never invokes fix actions.
+- Pre-commit hides LOW diagnostics and blocks only on HIGH.
+- Interactive check still invokes fix actions and post actions after successful recheck.

--- a/src/main/java/de/zorro909/codecheck/GitCommitCodeCheckCommand.java
+++ b/src/main/java/de/zorro909/codecheck/GitCommitCodeCheckCommand.java
@@ -1,49 +1,37 @@
 package de.zorro909.codecheck;
 
-import de.zorro909.codecheck.checks.ValidationError;
-import de.zorro909.codecheck.daemon.DaemonServer;
-import de.zorro909.codecheck.daemon.FileWatcher;
-import de.zorro909.codecheck.selector.FileSelector;
+import de.zorro909.codecheck.command.CodeCheckCommandService;
 import io.micronaut.configuration.picocli.MicronautFactory;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.Getter;
-import lombok.SneakyThrows;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
 
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Stream;
-
+import java.util.concurrent.Callable;
 
 /**
- * The GitCommitCodeCheckCommand class represents a command-line command that performs code checks on files
- * in a Git repository.
+ * Command-line entry point for Git Commit Code Check.
  */
 @Singleton
-@Command(name = "git-commit-code-check", description = "...", mixinStandardHelpOptions = true)
-public class GitCommitCodeCheckCommand implements Runnable {
+@Command(name = "git-commit-code-check",
+        description = "...",
+        mixinStandardHelpOptions = true,
+        subcommands = {
+                GitCommitCodeCheckCommand.CheckCommand.class,
+                GitCommitCodeCheckCommand.PreCommitCommand.class,
+                GitCommitCodeCheckCommand.StatusCommand.class,
+                GitCommitCodeCheckCommand.FixCommand.class
+        })
+public class GitCommitCodeCheckCommand implements Callable<Integer> {
 
     @Inject
-    RepositoryPathProvider repositoryPathProvider;
-
-    @Inject
-    Optional<DaemonServer> daemonServer;
-
-    @Inject
-    ValidationCheckPipeline validationCheckPipeline;
-
-    @Inject
-    FileSelector fileSelector;
-
-    @Inject
-    Optional<FileWatcher> fileWatcher;
+    CodeCheckCommandService commandService;
 
     @Getter
     @Option(names = {"-v", "--verbose"}, description = "...", defaultValue = "false")
@@ -66,10 +54,6 @@ public class GitCommitCodeCheckCommand implements Runnable {
     boolean git;
 
     @Getter
-    @Option(names = "--batch", defaultValue = "false")
-    boolean batch;
-
-    @Getter
     @Option(names = "--experimental", defaultValue = "false")
     boolean experimental;
 
@@ -83,57 +67,78 @@ public class GitCommitCodeCheckCommand implements Runnable {
 
     public static void main(String[] args) {
         try (ApplicationContext context = ApplicationContext.builder(
-                GitCommitCodeCheckCommand.class, Environment.CLI).start()) {
+                        GitCommitCodeCheckCommand.class, Environment.CLI)
+                .singletons((Object) args)
+                .start()) {
             CommandLine commandLine = new CommandLine(GitCommitCodeCheckCommand.class,
                                                       new MicronautFactory(
                                                               context)).setCaseInsensitiveEnumValuesAllowed(
                     true).setUsageHelpAutoWidth(true);
-            context.registerSingleton(args);
             int exitCode = commandLine.execute(args);
             System.exit(exitCode);
         }
     }
 
-    @SneakyThrows
-    public void run() {
-        // business logic here
-        if (verbose) {
-            System.out.println("Hi!");
-        }
-        if (daemon) {
-            if(watch){
-                fileWatcher.get().watch();
+    @Override
+    public Integer call() {
+        return commandService.startAssistantDaemon().exitCode();
+    }
+
+    @Command(name = "check", description = "Run a one-shot code check.")
+    static class CheckCommand implements Callable<Integer> {
+
+        @ParentCommand
+        GitCommitCodeCheckCommand parent;
+
+        @Option(names = "--batch", defaultValue = "false",
+                description = "Run without interactive fix actions.")
+        boolean batch;
+
+        @Override
+        public Integer call() {
+            if (batch) {
+                return parent.commandService.runBatchCheck().exitCode();
             }
-            daemonServer.get().run();
-            return;
-        }
-
-        Stream<Path> changedFiles = fileSelector.selectFiles();
-
-        Map<Path, List<ValidationError>> errorsMap = validationCheckPipeline.checkForErrors(
-                changedFiles);
-
-        // Can be dependent on IO Resources
-        changedFiles.close();
-
-        System.out.println("Overview of code checks:");
-        System.out.println("------------------------");
-        if (errorsMap.isEmpty()) {
-            System.out.println("No validation errors found. Great job!");
-        } else {
-            System.out.println("Validation errors found in " + errorsMap.size() + " files");
-            System.out.println("Here are the details:");
-
-            boolean success = validationCheckPipeline.executeFixActions(errorsMap);
-
-            if (!success && !noExitCode) {
-                System.exit(1);
-            }
-
-            validationCheckPipeline.executePostActions(errorsMap.keySet());
-
+            return parent.commandService.runInteractiveCheck(parent.noExitCode).exitCode();
         }
     }
 
+    @Command(name = "pre-commit", description = "Run deterministic pre-commit validation.")
+    static class PreCommitCommand implements Callable<Integer> {
 
+        @ParentCommand
+        GitCommitCodeCheckCommand parent;
+
+        @Override
+        public Integer call() {
+            return parent.commandService.runPreCommit().exitCode();
+        }
+    }
+
+    @Command(name = "status", description = "Print assistant daemon status.")
+    static class StatusCommand implements Callable<Integer> {
+
+        @ParentCommand
+        GitCommitCodeCheckCommand parent;
+
+        @Override
+        public Integer call() {
+            return parent.commandService.printStatus().exitCode();
+        }
+    }
+
+    @Command(name = "fix", description = "Apply an explicitly selected daemon fix.")
+    static class FixCommand implements Callable<Integer> {
+
+        @ParentCommand
+        GitCommitCodeCheckCommand parent;
+
+        @Parameters(index = "0", description = "Diagnostic identifier.")
+        String diagnosticId;
+
+        @Override
+        public Integer call() {
+            return parent.commandService.applyFix(diagnosticId).exitCode();
+        }
+    }
 }

--- a/src/main/java/de/zorro909/codecheck/command/AssistantDaemonController.java
+++ b/src/main/java/de/zorro909/codecheck/command/AssistantDaemonController.java
@@ -1,0 +1,12 @@
+package de.zorro909.codecheck.command;
+
+import java.io.PrintStream;
+
+public interface AssistantDaemonController {
+
+    void startOrAttach() throws Exception;
+
+    void printStatus(PrintStream out);
+
+    void applyFix(String diagnosticId) throws Exception;
+}

--- a/src/main/java/de/zorro909/codecheck/command/CodeCheckCommandService.java
+++ b/src/main/java/de/zorro909/codecheck/command/CodeCheckCommandService.java
@@ -1,0 +1,153 @@
+package de.zorro909.codecheck.command;
+
+import de.zorro909.codecheck.ValidationCheckPipeline;
+import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.selector.FileSelector;
+import jakarta.inject.Singleton;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+@Singleton
+public class CodeCheckCommandService {
+
+    private final AssistantDaemonController assistantDaemonController;
+    private final ValidationCheckPipeline validationCheckPipeline;
+    private final FileSelector fileSelector;
+    private final PrintStream out;
+    private final PrintStream err;
+
+    public CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
+                                   ValidationCheckPipeline validationCheckPipeline,
+                                   FileSelector fileSelector) {
+        this(assistantDaemonController, validationCheckPipeline, fileSelector, System.out,
+             System.err);
+    }
+
+    CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
+                            ValidationCheckPipeline validationCheckPipeline,
+                            FileSelector fileSelector,
+                            PrintStream out,
+                            PrintStream err) {
+        this.assistantDaemonController = assistantDaemonController;
+        this.validationCheckPipeline = validationCheckPipeline;
+        this.fileSelector = fileSelector;
+        this.out = out;
+        this.err = err;
+    }
+
+    public CommandOutcome startAssistantDaemon() {
+        try {
+            assistantDaemonController.startOrAttach();
+            return CommandOutcome.success();
+        } catch (Exception e) {
+            err.println("Failed to start or attach to assistant daemon: " + e.getMessage());
+            return CommandOutcome.failure();
+        }
+    }
+
+    public CommandOutcome runInteractiveCheck(boolean noExitCode) {
+        try {
+            Map<Path, List<ValidationError>> errorsMap = collectErrors();
+            printOverview(errorsMap, _ -> true);
+
+            if (errorsMap.isEmpty()) {
+                return CommandOutcome.success();
+            }
+
+            boolean fixed = validationCheckPipeline.executeFixActions(errorsMap);
+            if (fixed) {
+                validationCheckPipeline.executePostActions(errorsMap.keySet());
+                return CommandOutcome.success();
+            }
+
+            return noExitCode ? CommandOutcome.success() : CommandOutcome.failure();
+        } catch (IOException e) {
+            err.println("Failed to run interactive check: " + e.getMessage());
+            return CommandOutcome.failure();
+        }
+    }
+
+    public CommandOutcome runBatchCheck() {
+        return runNonInteractive("batch check", _ -> true);
+    }
+
+    public CommandOutcome runPreCommit() {
+        return runNonInteractive("pre-commit check",
+                                 error -> error.severity() != ValidationError.Severity.LOW);
+    }
+
+    public CommandOutcome printStatus() {
+        assistantDaemonController.printStatus(out);
+        return CommandOutcome.success();
+    }
+
+    public CommandOutcome applyFix(String diagnosticId) {
+        try {
+            assistantDaemonController.applyFix(diagnosticId);
+            return CommandOutcome.success();
+        } catch (Exception e) {
+            err.println("Failed to apply fix: " + e.getMessage());
+            return CommandOutcome.failure();
+        }
+    }
+
+    private CommandOutcome runNonInteractive(String label,
+                                             Predicate<ValidationError> diagnosticFilter) {
+        try {
+            Map<Path, List<ValidationError>> errorsMap = collectErrors();
+            printOverview(errorsMap, diagnosticFilter);
+            return hasHighSeverity(errorsMap) ? CommandOutcome.failure() : CommandOutcome.success();
+        } catch (IOException e) {
+            err.println("Failed to run " + label + ": " + e.getMessage());
+            return CommandOutcome.failure();
+        }
+    }
+
+    private Map<Path, List<ValidationError>> collectErrors() throws IOException {
+        try (Stream<Path> changedFiles = fileSelector.selectFiles()) {
+            return validationCheckPipeline.checkForErrors(changedFiles);
+        }
+    }
+
+    private void printOverview(Map<Path, List<ValidationError>> errorsMap,
+                               Predicate<ValidationError> diagnosticFilter) {
+        out.println("Overview of code checks:");
+        out.println("------------------------");
+        if (errorsMap.isEmpty()) {
+            out.println("No validation errors found.");
+            return;
+        }
+
+        long visibleErrors = errorsMap.values()
+                                      .stream()
+                                      .flatMap(List::stream)
+                                      .filter(diagnosticFilter)
+                                      .count();
+
+        if (visibleErrors == 0) {
+            out.println("No blocking validation errors found.");
+            return;
+        }
+
+        out.println("Validation diagnostics:");
+        errorsMap.values()
+                 .stream()
+                 .flatMap(List::stream)
+                 .filter(diagnosticFilter)
+                 .map(ValidationError::toString)
+                 .forEach(out::println);
+    }
+
+    private boolean hasHighSeverity(Map<Path, List<ValidationError>> errorsMap) {
+        return errorsMap.values()
+                        .stream()
+                        .flatMap(List::stream)
+                        .anyMatch(error -> error.severity() == ValidationError.Severity.HIGH);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/command/CommandOutcome.java
+++ b/src/main/java/de/zorro909/codecheck/command/CommandOutcome.java
@@ -1,0 +1,12 @@
+package de.zorro909.codecheck.command;
+
+public record CommandOutcome(int exitCode) {
+
+    public static CommandOutcome success() {
+        return new CommandOutcome(0);
+    }
+
+    public static CommandOutcome failure() {
+        return new CommandOutcome(1);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/command/LocalAssistantDaemonController.java
+++ b/src/main/java/de/zorro909/codecheck/command/LocalAssistantDaemonController.java
@@ -1,0 +1,32 @@
+package de.zorro909.codecheck.command;
+
+import de.zorro909.codecheck.daemon.DaemonServer;
+import jakarta.inject.Singleton;
+
+import java.io.PrintStream;
+
+@Singleton
+public class LocalAssistantDaemonController implements AssistantDaemonController {
+
+    private final DaemonServer daemonServer;
+
+    public LocalAssistantDaemonController(DaemonServer daemonServer) {
+        this.daemonServer = daemonServer;
+    }
+
+    @Override
+    public void startOrAttach() throws Exception {
+        daemonServer.run();
+    }
+
+    @Override
+    public void printStatus(PrintStream out) {
+        out.println("Assistant daemon status is not available yet.");
+    }
+
+    @Override
+    public void applyFix(String diagnosticId) {
+        throw new UnsupportedOperationException(
+                "Daemon-backed fix selection is not available yet for diagnostic " + diagnosticId);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/daemon/DaemonServer.java
+++ b/src/main/java/de/zorro909/codecheck/daemon/DaemonServer.java
@@ -2,7 +2,6 @@ package de.zorro909.codecheck.daemon;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
-import de.zorro909.codecheck.RequiresCliOption;
 import de.zorro909.codecheck.ValidationCheckPipeline;
 import de.zorro909.codecheck.checks.ValidationError;
 import de.zorro909.codecheck.selector.FileSelector;
@@ -24,7 +23,6 @@ import java.util.stream.Stream;
 /**
  * Represents a daemon server that runs a file selection process, starts an HTTP server, and runs indefinitely.
  */
-@RequiresCliOption("--daemon")
 @Singleton
 public class DaemonServer {
 
@@ -47,7 +45,6 @@ public class DaemonServer {
      * @throws InterruptedException   if the current thread is interrupted while sleeping.
      */
     public void run() throws IOException, InterruptedException {
-        fileSelector.selectFiles().forEach(this::updateFile);
         HttpServer server = getHttpServer();
         server.start();
         runServerIndefinitely();

--- a/src/test/java/de/zorro909/codecheck/GitCommitCodeCheckCommandTest.java
+++ b/src/test/java/de/zorro909/codecheck/GitCommitCodeCheckCommandTest.java
@@ -1,0 +1,122 @@
+package de.zorro909.codecheck;
+
+import de.zorro909.codecheck.command.CodeCheckCommandService;
+import de.zorro909.codecheck.command.CommandOutcome;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitCommitCodeCheckCommandTest {
+
+    @Test
+    void bareCommandRoutesToAssistantDaemon() {
+        RecordingCommandService service = new RecordingCommandService();
+
+        int exitCode = commandLine(service).execute();
+
+        assertThat(exitCode).isZero();
+        assertThat(service.calledMode).isEqualTo("daemon");
+    }
+
+    @Test
+    void checkCommandRoutesToInteractiveCheck() {
+        RecordingCommandService service = new RecordingCommandService();
+
+        int exitCode = commandLine(service).execute("check");
+
+        assertThat(exitCode).isZero();
+        assertThat(service.calledMode).isEqualTo("interactive");
+    }
+
+    @Test
+    void batchCheckRoutesToBatchCheck() {
+        RecordingCommandService service = new RecordingCommandService();
+
+        int exitCode = commandLine(service).execute("check", "--batch");
+
+        assertThat(exitCode).isZero();
+        assertThat(service.calledMode).isEqualTo("batch");
+    }
+
+    @Test
+    void preCommitCommandRoutesToPreCommit() {
+        RecordingCommandService service = new RecordingCommandService();
+
+        int exitCode = commandLine(service).execute("pre-commit");
+
+        assertThat(exitCode).isZero();
+        assertThat(service.calledMode).isEqualTo("pre-commit");
+    }
+
+    @Test
+    void statusCommandRoutesToStatus() {
+        RecordingCommandService service = new RecordingCommandService();
+
+        int exitCode = commandLine(service).execute("status");
+
+        assertThat(exitCode).isZero();
+        assertThat(service.calledMode).isEqualTo("status");
+    }
+
+    @Test
+    void fixCommandRoutesToExplicitFix() {
+        RecordingCommandService service = new RecordingCommandService();
+
+        int exitCode = commandLine(service).execute("fix", "diagnostic-1");
+
+        assertThat(exitCode).isZero();
+        assertThat(service.calledMode).isEqualTo("fix:diagnostic-1");
+    }
+
+    private CommandLine commandLine(RecordingCommandService service) {
+        GitCommitCodeCheckCommand command = new GitCommitCodeCheckCommand();
+        command.commandService = service;
+        return new CommandLine(command);
+    }
+
+    private static final class RecordingCommandService extends CodeCheckCommandService {
+
+        private String calledMode;
+
+        private RecordingCommandService() {
+            super(null, null, null);
+        }
+
+        @Override
+        public CommandOutcome startAssistantDaemon() {
+            calledMode = "daemon";
+            return CommandOutcome.success();
+        }
+
+        @Override
+        public CommandOutcome runInteractiveCheck(boolean noExitCode) {
+            calledMode = "interactive";
+            return CommandOutcome.success();
+        }
+
+        @Override
+        public CommandOutcome runBatchCheck() {
+            calledMode = "batch";
+            return CommandOutcome.success();
+        }
+
+        @Override
+        public CommandOutcome runPreCommit() {
+            calledMode = "pre-commit";
+            return CommandOutcome.success();
+        }
+
+        @Override
+        public CommandOutcome printStatus() {
+            calledMode = "status";
+            return CommandOutcome.success();
+        }
+
+        @Override
+        public CommandOutcome applyFix(String diagnosticId) {
+            calledMode = "fix:" + diagnosticId;
+            return CommandOutcome.success();
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/command/CodeCheckCommandServiceTest.java
+++ b/src/test/java/de/zorro909/codecheck/command/CodeCheckCommandServiceTest.java
@@ -1,0 +1,269 @@
+package de.zorro909.codecheck.command;
+
+import com.github.javaparser.Position;
+import de.zorro909.codecheck.ValidationCheckPipeline;
+import de.zorro909.codecheck.actions.FixAction;
+import de.zorro909.codecheck.actions.PostAction;
+import de.zorro909.codecheck.checks.CodeCheck;
+import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.selector.FileSelector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CodeCheckCommandServiceTest {
+
+    private RecordingDaemonController daemonController;
+    private ValidationCheckPipeline pipeline;
+    private List<CodeCheck> checks;
+    private List<FixAction> fixActions;
+    private List<PostAction> postActions;
+    private ByteArrayOutputStream stdout;
+    private ByteArrayOutputStream stderr;
+
+    @BeforeEach
+    void setUp() {
+        daemonController = new RecordingDaemonController();
+        pipeline = new ValidationCheckPipeline();
+        checks = new ArrayList<>();
+        fixActions = new ArrayList<>();
+        postActions = new ArrayList<>();
+        setField(pipeline, "codeChecker", checks);
+        setField(pipeline, "fixActions", fixActions);
+        setField(pipeline, "postActions", postActions);
+        stdout = new ByteArrayOutputStream();
+        stderr = new ByteArrayOutputStream();
+    }
+
+    @Test
+    void bareCommandStartsOrAttachesDaemonSilently() {
+        CodeCheckCommandService service = createService(Stream::empty);
+
+        CommandOutcome outcome = service.startAssistantDaemon();
+
+        assertThat(outcome.exitCode()).isZero();
+        assertThat(daemonController.startCalls).isEqualTo(1);
+        assertThat(output()).isEmpty();
+        assertThat(errorOutput()).isEmpty();
+    }
+
+    @Test
+    void daemonStartupFailureIsPrintedClearly() {
+        daemonController.startFailure = new IllegalStateException("port is already in use");
+        CodeCheckCommandService service = createService(Stream::empty);
+
+        CommandOutcome outcome = service.startAssistantDaemon();
+
+        assertThat(outcome.exitCode()).isEqualTo(1);
+        assertThat(errorOutput()).contains("Failed to start or attach to assistant daemon")
+                                 .contains("port is already in use");
+    }
+
+    @Test
+    void batchCheckDoesNotInvokeFixActions(@TempDir Path tempDir) throws Exception {
+        Path file = javaFile(tempDir);
+        AtomicBoolean fixInvoked = new AtomicBoolean(false);
+        checks.add(alwaysError("Low priority", ValidationError.Severity.LOW));
+        fixActions.add(new FixAction() {
+            @Override
+            public boolean canFixError(ValidationError validationError) {
+                return true;
+            }
+
+            @Override
+            public boolean fixError(ValidationError validationError) {
+                fixInvoked.set(true);
+                return true;
+            }
+        });
+        CodeCheckCommandService service = createService(() -> Stream.of(file));
+
+        CommandOutcome outcome = service.runBatchCheck();
+
+        assertThat(outcome.exitCode()).isZero();
+        assertThat(fixInvoked).isFalse();
+        assertThat(output()).contains("Low priority");
+    }
+
+    @Test
+    void preCommitHidesLowDiagnosticsAndBlocksOnlyOnHigh(@TempDir Path tempDir) throws Exception {
+        Path file = javaFile(tempDir);
+        checks.add(new CodeCheck() {
+            @Override
+            public boolean isResponsible(Path checkedFile) {
+                return true;
+            }
+
+            @Override
+            public List<ValidationError> check(Path checkedFile) {
+                return List.of(
+                        error(checkedFile, "Low detail", ValidationError.Severity.LOW),
+                        error(checkedFile, "Medium warning", ValidationError.Severity.MEDIUM),
+                        error(checkedFile, "High failure", ValidationError.Severity.HIGH));
+            }
+
+            @Override
+            public void resetCache(Path checkedFile) {
+            }
+        });
+        CodeCheckCommandService service = createService(() -> Stream.of(file));
+
+        CommandOutcome outcome = service.runPreCommit();
+
+        assertThat(outcome.exitCode()).isEqualTo(1);
+        assertThat(output()).doesNotContain("Low detail")
+                            .contains("Medium warning")
+                            .contains("High failure");
+    }
+
+    @Test
+    void preCommitDoesNotBlockOnMediumOnly(@TempDir Path tempDir) throws Exception {
+        Path file = javaFile(tempDir);
+        checks.add(alwaysError("Medium warning", ValidationError.Severity.MEDIUM));
+        CodeCheckCommandService service = createService(() -> Stream.of(file));
+
+        CommandOutcome outcome = service.runPreCommit();
+
+        assertThat(outcome.exitCode()).isZero();
+        assertThat(output()).contains("Medium warning");
+    }
+
+    @Test
+    void interactiveCheckInvokesFixActionsAndPostActionsAfterSuccessfulRecheck(
+            @TempDir Path tempDir) throws Exception {
+        Path file = javaFile(tempDir);
+        AtomicInteger checkCalls = new AtomicInteger();
+        AtomicBoolean fixInvoked = new AtomicBoolean(false);
+        AtomicBoolean postActionInvoked = new AtomicBoolean(false);
+        checks.add(new CodeCheck() {
+            @Override
+            public boolean isResponsible(Path checkedFile) {
+                return true;
+            }
+
+            @Override
+            public List<ValidationError> check(Path checkedFile) {
+                if (checkCalls.getAndIncrement() == 0) {
+                    return List.of(error(checkedFile, "Fixable", ValidationError.Severity.HIGH));
+                }
+                return List.of();
+            }
+
+            @Override
+            public void resetCache(Path checkedFile) {
+            }
+        });
+        fixActions.add(new FixAction() {
+            @Override
+            public boolean canFixError(ValidationError validationError) {
+                return true;
+            }
+
+            @Override
+            public boolean fixError(ValidationError validationError) {
+                fixInvoked.set(true);
+                return true;
+            }
+        });
+        postActions.add(files -> {
+            postActionInvoked.set(files.equals(Set.of(file)));
+            return true;
+        });
+        CodeCheckCommandService service = createService(() -> Stream.of(file));
+
+        CommandOutcome outcome = service.runInteractiveCheck(false);
+
+        assertThat(outcome.exitCode()).isZero();
+        assertThat(fixInvoked).isTrue();
+        assertThat(postActionInvoked).isTrue();
+    }
+
+    private CodeCheckCommandService createService(FileSelector fileSelector) {
+        return new CodeCheckCommandService(daemonController, pipeline, fileSelector,
+                                           new PrintStream(stdout, true, StandardCharsets.UTF_8),
+                                           new PrintStream(stderr, true, StandardCharsets.UTF_8));
+    }
+
+    private Path javaFile(Path tempDir) throws Exception {
+        Path file = tempDir.resolve("Example.java");
+        Files.writeString(file, "class Example {}");
+        return file;
+    }
+
+    private CodeCheck alwaysError(String message, ValidationError.Severity severity) {
+        return new CodeCheck() {
+            @Override
+            public boolean isResponsible(Path file) {
+                return true;
+            }
+
+            @Override
+            public List<ValidationError> check(Path file) {
+                return List.of(error(file, message, severity));
+            }
+
+            @Override
+            public void resetCache(Path file) {
+            }
+        };
+    }
+
+    private ValidationError error(Path file, String message, ValidationError.Severity severity) {
+        return new ValidationError(file, message, new Position(1, 1), severity);
+    }
+
+    private String output() {
+        return stdout.toString(StandardCharsets.UTF_8);
+    }
+
+    private String errorOutput() {
+        return stderr.toString(StandardCharsets.UTF_8);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set field: " + fieldName, e);
+        }
+    }
+
+    private static final class RecordingDaemonController implements AssistantDaemonController {
+
+        private int startCalls;
+        private RuntimeException startFailure;
+
+        @Override
+        public void startOrAttach() {
+            startCalls++;
+            if (startFailure != null) {
+                throw startFailure;
+            }
+        }
+
+        @Override
+        public void printStatus(PrintStream out) {
+            out.println("status");
+        }
+
+        @Override
+        public void applyFix(String diagnosticId) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the CR-001 implementation specification
- introduce explicit assistant, check, batch, pre-commit, status, and fix command routing
- keep batch/pre-commit non-interactive and hide LOW pre-commit diagnostics
- make daemon startup silent by removing eager validation output

## Tests
- ./mvnw test