### PR TITLE
CR-002: Configuration model

### DIFF
--- a/docs/implementation-specs/CR-002-configuration-model.md
+++ b/docs/implementation-specs/CR-002-configuration-model.md
@@ -38,8 +38,12 @@ accept YAML names such as `docker-mvnd`, `maven-defaults`, and `reuse-if-fresh`.
 
 ## Validation
 
-Invalid YAML, wrong node types, unknown enum values, invalid durations, and invalid integer ranges
-raise `ConfigException` with the config file and field path in the message.
+Invalid YAML, wrong node types, unknown enum values, invalid durations, invalid regular
+expressions, and invalid integer ranges raise `ConfigException` with the config file and field
+path in the message.
+
+Unknown config keys do not fail loading; they produce a warning naming the config file, the field
+path, and the unknown key, so typos are surfaced without breaking existing configs.
 
 ## Command Integration
 
@@ -54,3 +58,5 @@ configuration prevents the command from running and returns a non-zero exit code
 - Maven goals and Docker image are configurable from repo config.
 - CLI overrides win over file config.
 - Invalid config fails fast with field-specific diagnostics.
+- Unknown config keys produce warnings with field paths; known keys stay silent.
+- The loader bean resolves through the qualified repository directory path.

--- a/docs/implementation-specs/CR-002-configuration-model.md
+++ b/docs/implementation-specs/CR-002-configuration-model.md
@@ -1,0 +1,56 @@
+# CR-002 Implementation Specification: Configuration Model
+
+## Scope
+
+This increment adds typed configuration loading for built-in defaults, user config, repository
+config, and command-scoped overrides. Later daemon and watcher branches will use the same loader
+to restart on config file changes.
+
+## Locations
+
+- User config: `~/.config/git-commit-code-check/config.yaml`
+- Repository config: `<repo>/.codecheck.yaml`
+
+Missing files are accepted.
+
+## Precedence
+
+Configuration is resolved in this order:
+
+```text
+built-in defaults < user config < repo config < CLI overrides
+```
+
+Repo config wins over user config so repository policy is reproducible.
+
+## Typed Model
+
+The internal model is `CodeCheckConfig` with typed nested domains:
+
+- `git`: main branches, release branch pattern, restage-after-fix
+- `daemon`: inactivity timeout, save debounce, transport
+- `java`: language level, generated source detection
+- `maven`: runner, mvnd preference, Docker settings, goals, args, targeted test property
+- `coverage`: provider, freshness mode, report paths
+
+Durations are parsed into `java.time.Duration`. Enum values are parsed case-insensitively and
+accept YAML names such as `docker-mvnd`, `maven-defaults`, and `reuse-if-fresh`.
+
+## Validation
+
+Invalid YAML, wrong node types, unknown enum values, invalid durations, and invalid integer ranges
+raise `ConfigException` with the config file and field path in the message.
+
+## Command Integration
+
+`CodeCheckCommandService` loads configuration before daemon startup or validation commands. Invalid
+configuration prevents the command from running and returns a non-zero exit code with a clear error.
+
+## Tests
+
+- Missing config files return built-in defaults.
+- User config overrides defaults.
+- Repo config overrides user config.
+- Maven goals and Docker image are configurable from repo config.
+- CLI overrides win over file config.
+- Invalid config fails fast with field-specific diagnostics.

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.4</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/de/zorro909/codecheck/RepositoryPathProvider.java
+++ b/src/main/java/de/zorro909/codecheck/RepositoryPathProvider.java
@@ -2,13 +2,17 @@ package de.zorro909.codecheck;
 
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
+import jakarta.inject.Named;
 
 import java.nio.file.Path;
 
 @Factory
 public class RepositoryPathProvider {
 
+    public static final String REPOSITORY_DIRECTORY = "repositoryDirectory";
+
     @Bean
+    @Named(REPOSITORY_DIRECTORY)
     public Path repositoryDirectory(){
         return Path.of("");
     }

--- a/src/main/java/de/zorro909/codecheck/command/CodeCheckCommandService.java
+++ b/src/main/java/de/zorro909/codecheck/command/CodeCheckCommandService.java
@@ -2,7 +2,11 @@ package de.zorro909.codecheck.command;
 
 import de.zorro909.codecheck.ValidationCheckPipeline;
 import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import de.zorro909.codecheck.config.ConfigException;
+import de.zorro909.codecheck.config.ConfigOverrides;
 import de.zorro909.codecheck.selector.FileSelector;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import java.io.IOException;
@@ -19,14 +23,24 @@ public class CodeCheckCommandService {
     private final AssistantDaemonController assistantDaemonController;
     private final ValidationCheckPipeline validationCheckPipeline;
     private final FileSelector fileSelector;
+    private final CodeCheckConfigLoader configLoader;
     private final PrintStream out;
     private final PrintStream err;
+
+    @Inject
+    public CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
+                                   ValidationCheckPipeline validationCheckPipeline,
+                                   FileSelector fileSelector,
+                                   CodeCheckConfigLoader configLoader) {
+        this(assistantDaemonController, validationCheckPipeline, fileSelector, configLoader,
+             System.out, System.err);
+    }
 
     public CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
                                    ValidationCheckPipeline validationCheckPipeline,
                                    FileSelector fileSelector) {
-        this(assistantDaemonController, validationCheckPipeline, fileSelector, System.out,
-             System.err);
+        this(assistantDaemonController, validationCheckPipeline, fileSelector,
+             CodeCheckConfigLoader.defaultsOnly(), System.out, System.err);
     }
 
     CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
@@ -34,14 +48,28 @@ public class CodeCheckCommandService {
                             FileSelector fileSelector,
                             PrintStream out,
                             PrintStream err) {
+        this(assistantDaemonController, validationCheckPipeline, fileSelector,
+             CodeCheckConfigLoader.defaultsOnly(), out, err);
+    }
+
+    CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
+                            ValidationCheckPipeline validationCheckPipeline,
+                            FileSelector fileSelector,
+                            CodeCheckConfigLoader configLoader,
+                            PrintStream out,
+                            PrintStream err) {
         this.assistantDaemonController = assistantDaemonController;
         this.validationCheckPipeline = validationCheckPipeline;
         this.fileSelector = fileSelector;
+        this.configLoader = configLoader;
         this.out = out;
         this.err = err;
     }
 
     public CommandOutcome startAssistantDaemon() {
+        if (!loadConfig()) {
+            return CommandOutcome.failure();
+        }
         try {
             assistantDaemonController.startOrAttach();
             return CommandOutcome.success();
@@ -52,6 +80,9 @@ public class CodeCheckCommandService {
     }
 
     public CommandOutcome runInteractiveCheck(boolean noExitCode) {
+        if (!loadConfig()) {
+            return CommandOutcome.failure();
+        }
         try {
             Map<Path, List<ValidationError>> errorsMap = collectErrors();
             printOverview(errorsMap, _ -> true);
@@ -83,11 +114,17 @@ public class CodeCheckCommandService {
     }
 
     public CommandOutcome printStatus() {
+        if (!loadConfig()) {
+            return CommandOutcome.failure();
+        }
         assistantDaemonController.printStatus(out);
         return CommandOutcome.success();
     }
 
     public CommandOutcome applyFix(String diagnosticId) {
+        if (!loadConfig()) {
+            return CommandOutcome.failure();
+        }
         try {
             assistantDaemonController.applyFix(diagnosticId);
             return CommandOutcome.success();
@@ -99,6 +136,9 @@ public class CodeCheckCommandService {
 
     private CommandOutcome runNonInteractive(String label,
                                              Predicate<ValidationError> diagnosticFilter) {
+        if (!loadConfig()) {
+            return CommandOutcome.failure();
+        }
         try {
             Map<Path, List<ValidationError>> errorsMap = collectErrors();
             printOverview(errorsMap, diagnosticFilter);
@@ -149,5 +189,15 @@ public class CodeCheckCommandService {
                         .stream()
                         .flatMap(List::stream)
                         .anyMatch(error -> error.severity() == ValidationError.Severity.HIGH);
+    }
+
+    private boolean loadConfig() {
+        try {
+            configLoader.load(ConfigOverrides.none());
+            return true;
+        } catch (ConfigException e) {
+            err.println(e.getMessage());
+            return false;
+        }
     }
 }

--- a/src/main/java/de/zorro909/codecheck/config/CodeCheckConfig.java
+++ b/src/main/java/de/zorro909/codecheck/config/CodeCheckConfig.java
@@ -2,7 +2,6 @@ package de.zorro909.codecheck.config;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.regex.Pattern;
 
 public record CodeCheckConfig(Git git,
                               Daemon daemon,
@@ -12,8 +11,7 @@ public record CodeCheckConfig(Git git,
 
     public static CodeCheckConfig defaults() {
         return new CodeCheckConfig(
-                new Git(List.of("develop", "main", "master"), Pattern.compile("release/.*"),
-                        true),
+                new Git(List.of("develop", "main", "master"), "release/.*", true),
                 new Daemon(Duration.ofMinutes(30), Duration.ofSeconds(5), Transport.WEBSOCKET),
                 new JavaProject(25, GeneratedSourceDetection.MAVEN_DEFAULTS),
                 new Maven(MavenRunner.DOCKER_MVND, true,
@@ -45,7 +43,7 @@ public record CodeCheckConfig(Git git,
     }
 
     public record Git(List<String> mainBranches,
-                      Pattern releaseBranchPattern,
+                      String releaseBranchPattern,
                       boolean restageAfterFix) {
     }
 

--- a/src/main/java/de/zorro909/codecheck/config/CodeCheckConfig.java
+++ b/src/main/java/de/zorro909/codecheck/config/CodeCheckConfig.java
@@ -1,0 +1,98 @@
+package de.zorro909.codecheck.config;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public record CodeCheckConfig(Git git,
+                              Daemon daemon,
+                              JavaProject javaProject,
+                              Maven maven,
+                              Coverage coverage) {
+
+    public static CodeCheckConfig defaults() {
+        return new CodeCheckConfig(
+                new Git(List.of("develop", "main", "master"), Pattern.compile("release/.*"),
+                        true),
+                new Daemon(Duration.ofMinutes(30), Duration.ofSeconds(5), Transport.WEBSOCKET),
+                new JavaProject(25, GeneratedSourceDetection.MAVEN_DEFAULTS),
+                new Maven(MavenRunner.DOCKER_MVND, true,
+                          new Docker("team/mvnd-jdk25:latest", Duration.ofMinutes(10), true),
+                          List.of("test", "jacoco:report"), List.of(), "-Dtest"),
+                new Coverage(CoverageProvider.JACOCO, CoverageFreshnessMode.REUSE_IF_FRESH,
+                             List.of("target/site/jacoco/jacoco.xml",
+                                     "*/target/site/jacoco/jacoco.xml")));
+    }
+
+    public CodeCheckConfig withGit(Git git) {
+        return new CodeCheckConfig(git, daemon, javaProject, maven, coverage);
+    }
+
+    public CodeCheckConfig withDaemon(Daemon daemon) {
+        return new CodeCheckConfig(git, daemon, javaProject, maven, coverage);
+    }
+
+    public CodeCheckConfig withJavaProject(JavaProject javaProject) {
+        return new CodeCheckConfig(git, daemon, javaProject, maven, coverage);
+    }
+
+    public CodeCheckConfig withMaven(Maven maven) {
+        return new CodeCheckConfig(git, daemon, javaProject, maven, coverage);
+    }
+
+    public CodeCheckConfig withCoverage(Coverage coverage) {
+        return new CodeCheckConfig(git, daemon, javaProject, maven, coverage);
+    }
+
+    public record Git(List<String> mainBranches,
+                      Pattern releaseBranchPattern,
+                      boolean restageAfterFix) {
+    }
+
+    public record Daemon(Duration inactivityTimeout,
+                         Duration saveDebounce,
+                         Transport transport) {
+    }
+
+    public record JavaProject(int languageLevel,
+                              GeneratedSourceDetection generatedSourceDetection) {
+    }
+
+    public record Maven(MavenRunner runner,
+                        boolean preferMvnd,
+                        Docker docker,
+                        List<String> goals,
+                        List<String> args,
+                        String targetedTestProperty) {
+    }
+
+    public record Docker(String image,
+                         Duration containerIdleTimeout,
+                         boolean mountM2) {
+    }
+
+    public record Coverage(CoverageProvider provider,
+                           CoverageFreshnessMode freshnessMode,
+                           List<String> reportPaths) {
+    }
+
+    public enum Transport {
+        WEBSOCKET
+    }
+
+    public enum GeneratedSourceDetection {
+        MAVEN_DEFAULTS
+    }
+
+    public enum MavenRunner {
+        DOCKER_MVND
+    }
+
+    public enum CoverageProvider {
+        JACOCO
+    }
+
+    public enum CoverageFreshnessMode {
+        REUSE_IF_FRESH
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/config/CodeCheckConfigLoader.java
+++ b/src/main/java/de/zorro909/codecheck/config/CodeCheckConfigLoader.java
@@ -1,0 +1,22 @@
+package de.zorro909.codecheck.config;
+
+public interface CodeCheckConfigLoader {
+
+    CodeCheckConfig load();
+
+    CodeCheckConfig load(ConfigOverrides overrides);
+
+    static CodeCheckConfigLoader defaultsOnly() {
+        return new CodeCheckConfigLoader() {
+            @Override
+            public CodeCheckConfig load() {
+                return CodeCheckConfig.defaults();
+            }
+
+            @Override
+            public CodeCheckConfig load(ConfigOverrides overrides) {
+                return overrides.apply(CodeCheckConfig.defaults());
+            }
+        };
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/config/CodeCheckConfigParser.java
+++ b/src/main/java/de/zorro909/codecheck/config/CodeCheckConfigParser.java
@@ -15,12 +15,34 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 final class CodeCheckConfigParser {
 
+    private static final Set<String> ROOT_KEYS = Set.of("git", "daemon", "java", "maven",
+                                                        "coverage");
+    private static final Set<String> GIT_KEYS = Set.of("mainBranches", "releaseBranchPattern",
+                                                       "restageAfterFix");
+    private static final Set<String> DAEMON_KEYS = Set.of("inactivityTimeout", "saveDebounce",
+                                                          "transport");
+    private static final Set<String> JAVA_KEYS = Set.of("languageLevel",
+                                                        "generatedSourceDetection");
+    private static final Set<String> MAVEN_KEYS = Set.of("runner", "preferMvnd", "docker",
+                                                         "goals", "args", "targetedTestProperty");
+    private static final Set<String> DOCKER_KEYS = Set.of("image", "containerIdleTimeout",
+                                                          "mountM2");
+    private static final Set<String> COVERAGE_KEYS = Set.of("provider", "freshnessMode",
+                                                            "reportPaths");
+
     private final Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+    private final Consumer<String> warningConsumer;
+
+    CodeCheckConfigParser(Consumer<String> warningConsumer) {
+        this.warningConsumer = warningConsumer;
+    }
 
     CodeCheckConfig applyIfPresent(Path configPath, CodeCheckConfig base) {
         if (!Files.exists(configPath)) {
@@ -46,6 +68,7 @@ final class CodeCheckConfigParser {
         }
 
         Map<String, Object> rootObject = stringKeyMap(rootMap, configPath, "<root>");
+        warnUnknownKeys(rootObject, ROOT_KEYS, configPath, "<root>");
         CodeCheckConfig config = base;
         Map<String, Object> git = object(rootObject, "git", configPath, "git");
         if (git != null) {
@@ -72,11 +95,12 @@ final class CodeCheckConfigParser {
 
     private CodeCheckConfig.Git applyGit(Path configPath, Map<String, Object> node,
                                          CodeCheckConfig.Git base) {
+        warnUnknownKeys(node, GIT_KEYS, configPath, "git");
         List<String> mainBranches = stringList(node, "mainBranches", configPath,
                                                "git.mainBranches", base.mainBranches());
-        Pattern releaseBranchPattern = pattern(node, "releaseBranchPattern", configPath,
-                                               "git.releaseBranchPattern",
-                                               base.releaseBranchPattern());
+        String releaseBranchPattern = pattern(node, "releaseBranchPattern", configPath,
+                                              "git.releaseBranchPattern",
+                                              base.releaseBranchPattern());
         Boolean restageAfterFix = bool(node, "restageAfterFix", configPath,
                                        "git.restageAfterFix");
         return new CodeCheckConfig.Git(mainBranches, releaseBranchPattern,
@@ -86,6 +110,7 @@ final class CodeCheckConfigParser {
 
     private CodeCheckConfig.Daemon applyDaemon(Path configPath, Map<String, Object> node,
                                                CodeCheckConfig.Daemon base) {
+        warnUnknownKeys(node, DAEMON_KEYS, configPath, "daemon");
         Duration inactivityTimeout = duration(node, "inactivityTimeout", configPath,
                                               "daemon.inactivityTimeout",
                                               base.inactivityTimeout());
@@ -100,6 +125,7 @@ final class CodeCheckConfigParser {
 
     private CodeCheckConfig.JavaProject applyJava(Path configPath, Map<String, Object> node,
                                                   CodeCheckConfig.JavaProject base) {
+        warnUnknownKeys(node, JAVA_KEYS, configPath, "java");
         Integer languageLevel = integer(node, "languageLevel", configPath, "java.languageLevel");
         if (languageLevel != null && languageLevel < 8) {
             throw invalid(configPath, "java.languageLevel", "must be at least 8");
@@ -114,6 +140,7 @@ final class CodeCheckConfigParser {
 
     private CodeCheckConfig.Maven applyMaven(Path configPath, Map<String, Object> node,
                                              CodeCheckConfig.Maven base) {
+        warnUnknownKeys(node, MAVEN_KEYS, configPath, "maven");
         CodeCheckConfig.MavenRunner runner = enumValue(node, "runner", configPath,
                                                        "maven.runner",
                                                        CodeCheckConfig.MavenRunner.class,
@@ -135,6 +162,7 @@ final class CodeCheckConfigParser {
 
     private CodeCheckConfig.Docker applyDocker(Path configPath, Map<String, Object> node,
                                                CodeCheckConfig.Docker base) {
+        warnUnknownKeys(node, DOCKER_KEYS, configPath, "maven.docker");
         String image = string(node, "image", configPath, "maven.docker.image", base.image());
         Duration containerIdleTimeout = duration(node, "containerIdleTimeout", configPath,
                                                  "maven.docker.containerIdleTimeout",
@@ -146,6 +174,7 @@ final class CodeCheckConfigParser {
 
     private CodeCheckConfig.Coverage applyCoverage(Path configPath, Map<String, Object> node,
                                                    CodeCheckConfig.Coverage base) {
+        warnUnknownKeys(node, COVERAGE_KEYS, configPath, "coverage");
         CodeCheckConfig.CoverageProvider provider = enumValue(node, "provider", configPath,
                                                               "coverage.provider",
                                                               CodeCheckConfig.CoverageProvider.class,
@@ -247,17 +276,18 @@ final class CodeCheckConfigParser {
         return parseDuration(configPath, path, value);
     }
 
-    private Pattern pattern(Map<String, Object> parent, String field, Path configPath,
-                            String path, Pattern fallback) {
+    private String pattern(Map<String, Object> parent, String field, Path configPath,
+                           String path, String fallback) {
         String value = string(parent, field, configPath, path, null);
         if (value == null) {
             return fallback;
         }
         try {
-            return Pattern.compile(value);
+            Pattern.compile(value);
         } catch (PatternSyntaxException e) {
             throw invalid(configPath, path, "invalid regular expression: " + e.getDescription());
         }
+        return value;
     }
 
     private <T extends Enum<T>> T enumValue(Map<String, Object> parent, String field,
@@ -300,6 +330,16 @@ final class CodeCheckConfigParser {
 
     private long longPrefix(String value, int suffixLength) {
         return Long.parseLong(value.substring(0, value.length() - suffixLength));
+    }
+
+    private void warnUnknownKeys(Map<String, Object> node, Set<String> knownKeys,
+                                 Path configPath, String path) {
+        for (String key : node.keySet()) {
+            if (!knownKeys.contains(key)) {
+                warningConsumer.accept("Config warning in " + configPath + " at " + path
+                                       + ": unknown key '" + key + "'");
+            }
+        }
     }
 
     private ConfigException invalid(Path configPath, String path, String message) {

--- a/src/main/java/de/zorro909/codecheck/config/CodeCheckConfigParser.java
+++ b/src/main/java/de/zorro909/codecheck/config/CodeCheckConfigParser.java
@@ -1,0 +1,309 @@
+package de.zorro909.codecheck.config;
+
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.LoaderOptions;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+final class CodeCheckConfigParser {
+
+    private final Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+
+    CodeCheckConfig applyIfPresent(Path configPath, CodeCheckConfig base) {
+        if (!Files.exists(configPath)) {
+            return base;
+        }
+
+        Object root;
+        try (Reader reader = Files.newBufferedReader(configPath)) {
+            root = yaml.load(reader);
+        } catch (YAMLException e) {
+            throw new ConfigException("Invalid config YAML in " + configPath + ": "
+                                      + e.getMessage(), e);
+        } catch (IOException e) {
+            throw new ConfigException("Unable to read config " + configPath + ": "
+                                      + e.getMessage(), e);
+        }
+
+        if (root == null) {
+            return base;
+        }
+        if (!(root instanceof Map<?, ?> rootMap)) {
+            throw invalid(configPath, "<root>", "expected a YAML object");
+        }
+
+        Map<String, Object> rootObject = stringKeyMap(rootMap, configPath, "<root>");
+        CodeCheckConfig config = base;
+        Map<String, Object> git = object(rootObject, "git", configPath, "git");
+        if (git != null) {
+            config = config.withGit(applyGit(configPath, git, config.git()));
+        }
+        Map<String, Object> daemon = object(rootObject, "daemon", configPath, "daemon");
+        if (daemon != null) {
+            config = config.withDaemon(applyDaemon(configPath, daemon, config.daemon()));
+        }
+        Map<String, Object> java = object(rootObject, "java", configPath, "java");
+        if (java != null) {
+            config = config.withJavaProject(applyJava(configPath, java, config.javaProject()));
+        }
+        Map<String, Object> maven = object(rootObject, "maven", configPath, "maven");
+        if (maven != null) {
+            config = config.withMaven(applyMaven(configPath, maven, config.maven()));
+        }
+        Map<String, Object> coverage = object(rootObject, "coverage", configPath, "coverage");
+        if (coverage != null) {
+            config = config.withCoverage(applyCoverage(configPath, coverage, config.coverage()));
+        }
+        return config;
+    }
+
+    private CodeCheckConfig.Git applyGit(Path configPath, Map<String, Object> node,
+                                         CodeCheckConfig.Git base) {
+        List<String> mainBranches = stringList(node, "mainBranches", configPath,
+                                               "git.mainBranches", base.mainBranches());
+        Pattern releaseBranchPattern = pattern(node, "releaseBranchPattern", configPath,
+                                               "git.releaseBranchPattern",
+                                               base.releaseBranchPattern());
+        Boolean restageAfterFix = bool(node, "restageAfterFix", configPath,
+                                       "git.restageAfterFix");
+        return new CodeCheckConfig.Git(mainBranches, releaseBranchPattern,
+                                       restageAfterFix == null ? base.restageAfterFix()
+                                                               : restageAfterFix);
+    }
+
+    private CodeCheckConfig.Daemon applyDaemon(Path configPath, Map<String, Object> node,
+                                               CodeCheckConfig.Daemon base) {
+        Duration inactivityTimeout = duration(node, "inactivityTimeout", configPath,
+                                              "daemon.inactivityTimeout",
+                                              base.inactivityTimeout());
+        Duration saveDebounce = duration(node, "saveDebounce", configPath,
+                                         "daemon.saveDebounce", base.saveDebounce());
+        CodeCheckConfig.Transport transport = enumValue(node, "transport", configPath,
+                                                        "daemon.transport",
+                                                        CodeCheckConfig.Transport.class,
+                                                        base.transport());
+        return new CodeCheckConfig.Daemon(inactivityTimeout, saveDebounce, transport);
+    }
+
+    private CodeCheckConfig.JavaProject applyJava(Path configPath, Map<String, Object> node,
+                                                  CodeCheckConfig.JavaProject base) {
+        Integer languageLevel = integer(node, "languageLevel", configPath, "java.languageLevel");
+        if (languageLevel != null && languageLevel < 8) {
+            throw invalid(configPath, "java.languageLevel", "must be at least 8");
+        }
+        CodeCheckConfig.GeneratedSourceDetection generatedSourceDetection = enumValue(
+                node, "generatedSourceDetection", configPath, "java.generatedSourceDetection",
+                CodeCheckConfig.GeneratedSourceDetection.class, base.generatedSourceDetection());
+        return new CodeCheckConfig.JavaProject(
+                languageLevel == null ? base.languageLevel() : languageLevel,
+                generatedSourceDetection);
+    }
+
+    private CodeCheckConfig.Maven applyMaven(Path configPath, Map<String, Object> node,
+                                             CodeCheckConfig.Maven base) {
+        CodeCheckConfig.MavenRunner runner = enumValue(node, "runner", configPath,
+                                                       "maven.runner",
+                                                       CodeCheckConfig.MavenRunner.class,
+                                                       base.runner());
+        Boolean preferMvnd = bool(node, "preferMvnd", configPath, "maven.preferMvnd");
+        Map<String, Object> docker = object(node, "docker", configPath, "maven.docker");
+        CodeCheckConfig.Docker dockerConfig = docker == null ? base.docker()
+                                                             : applyDocker(configPath, docker,
+                                                                           base.docker());
+        List<String> goals = stringList(node, "goals", configPath, "maven.goals", base.goals());
+        List<String> args = stringList(node, "args", configPath, "maven.args", base.args());
+        String targetedTestProperty = string(node, "targetedTestProperty", configPath,
+                                             "maven.targetedTestProperty",
+                                             base.targetedTestProperty());
+        return new CodeCheckConfig.Maven(runner, preferMvnd == null ? base.preferMvnd()
+                                                                    : preferMvnd,
+                                         dockerConfig, goals, args, targetedTestProperty);
+    }
+
+    private CodeCheckConfig.Docker applyDocker(Path configPath, Map<String, Object> node,
+                                               CodeCheckConfig.Docker base) {
+        String image = string(node, "image", configPath, "maven.docker.image", base.image());
+        Duration containerIdleTimeout = duration(node, "containerIdleTimeout", configPath,
+                                                 "maven.docker.containerIdleTimeout",
+                                                 base.containerIdleTimeout());
+        Boolean mountM2 = bool(node, "mountM2", configPath, "maven.docker.mountM2");
+        return new CodeCheckConfig.Docker(image, containerIdleTimeout,
+                                          mountM2 == null ? base.mountM2() : mountM2);
+    }
+
+    private CodeCheckConfig.Coverage applyCoverage(Path configPath, Map<String, Object> node,
+                                                   CodeCheckConfig.Coverage base) {
+        CodeCheckConfig.CoverageProvider provider = enumValue(node, "provider", configPath,
+                                                              "coverage.provider",
+                                                              CodeCheckConfig.CoverageProvider.class,
+                                                              base.provider());
+        CodeCheckConfig.CoverageFreshnessMode freshnessMode = enumValue(
+                node, "freshnessMode", configPath, "coverage.freshnessMode",
+                CodeCheckConfig.CoverageFreshnessMode.class, base.freshnessMode());
+        List<String> reportPaths = stringList(node, "reportPaths", configPath,
+                                              "coverage.reportPaths", base.reportPaths());
+        return new CodeCheckConfig.Coverage(provider, freshnessMode, reportPaths);
+    }
+
+    private Map<String, Object> object(Map<String, Object> parent, String field, Path configPath,
+                                       String path) {
+        Object node = parent.get(field);
+        if (node == null) {
+            return null;
+        }
+        if (!(node instanceof Map<?, ?> map)) {
+            throw invalid(configPath, path, "expected an object");
+        }
+        return stringKeyMap(map, configPath, path);
+    }
+
+    private Map<String, Object> stringKeyMap(Map<?, ?> map, Path configPath, String path) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (!(entry.getKey() instanceof String key)) {
+                throw invalid(configPath, path, "expected string keys");
+            }
+            result.put(key, entry.getValue());
+        }
+        return result;
+    }
+
+    private String string(Map<String, Object> parent, String field, Path configPath, String path,
+                          String fallback) {
+        Object node = parent.get(field);
+        if (node == null) {
+            return fallback;
+        }
+        if (!(node instanceof String value)) {
+            throw invalid(configPath, path, "expected a string");
+        }
+        return value;
+    }
+
+    private List<String> stringList(Map<String, Object> parent, String field, Path configPath,
+                                    String path, List<String> fallback) {
+        Object node = parent.get(field);
+        if (node == null) {
+            return fallback;
+        }
+        if (!(node instanceof List<?> list)) {
+            throw invalid(configPath, path, "expected a list of strings");
+        }
+        List<String> values = new ArrayList<>();
+        for (Object element : list) {
+            if (!(element instanceof String value)) {
+                throw invalid(configPath, path, "expected a list of strings");
+            }
+            values.add(value);
+        }
+        return List.copyOf(values);
+    }
+
+    private Boolean bool(Map<String, Object> parent, String field, Path configPath, String path) {
+        Object node = parent.get(field);
+        if (node == null) {
+            return null;
+        }
+        if (!(node instanceof Boolean value)) {
+            throw invalid(configPath, path, "expected true or false");
+        }
+        return value;
+    }
+
+    private Integer integer(Map<String, Object> parent, String field, Path configPath,
+                            String path) {
+        Object node = parent.get(field);
+        if (node == null) {
+            return null;
+        }
+        if (!(node instanceof Integer value)) {
+            throw invalid(configPath, path, "expected an integer");
+        }
+        return value;
+    }
+
+    private Duration duration(Map<String, Object> parent, String field, Path configPath,
+                              String path, Duration fallback) {
+        Object node = parent.get(field);
+        if (node == null) {
+            return fallback;
+        }
+        if (!(node instanceof String value)) {
+            throw invalid(configPath, path, "expected a duration string");
+        }
+        return parseDuration(configPath, path, value);
+    }
+
+    private Pattern pattern(Map<String, Object> parent, String field, Path configPath,
+                            String path, Pattern fallback) {
+        String value = string(parent, field, configPath, path, null);
+        if (value == null) {
+            return fallback;
+        }
+        try {
+            return Pattern.compile(value);
+        } catch (PatternSyntaxException e) {
+            throw invalid(configPath, path, "invalid regular expression: " + e.getDescription());
+        }
+    }
+
+    private <T extends Enum<T>> T enumValue(Map<String, Object> parent, String field,
+                                            Path configPath, String path, Class<T> enumType,
+                                            T fallback) {
+        String value = string(parent, field, configPath, path, null);
+        if (value == null) {
+            return fallback;
+        }
+        String normalized = value.trim()
+                                 .replace('-', '_')
+                                 .toUpperCase(Locale.ROOT);
+        try {
+            return Enum.valueOf(enumType, normalized);
+        } catch (IllegalArgumentException e) {
+            throw invalid(configPath, path, "unknown value '" + value + "'");
+        }
+    }
+
+    private Duration parseDuration(Path configPath, String path, String value) {
+        String trimmed = value.trim().toLowerCase(Locale.ROOT);
+        try {
+            if (trimmed.endsWith("ms")) {
+                return Duration.ofMillis(longPrefix(trimmed, 2));
+            }
+            if (trimmed.endsWith("s")) {
+                return Duration.ofSeconds(longPrefix(trimmed, 1));
+            }
+            if (trimmed.endsWith("m")) {
+                return Duration.ofMinutes(longPrefix(trimmed, 1));
+            }
+            if (trimmed.endsWith("h")) {
+                return Duration.ofHours(longPrefix(trimmed, 1));
+            }
+            return Duration.parse(value);
+        } catch (RuntimeException e) {
+            throw invalid(configPath, path, "invalid duration '" + value + "'");
+        }
+    }
+
+    private long longPrefix(String value, int suffixLength) {
+        return Long.parseLong(value.substring(0, value.length() - suffixLength));
+    }
+
+    private ConfigException invalid(Path configPath, String path, String message) {
+        return new ConfigException("Invalid config " + configPath + " at " + path + ": "
+                                   + message);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/config/ConfigException.java
+++ b/src/main/java/de/zorro909/codecheck/config/ConfigException.java
@@ -1,0 +1,12 @@
+package de.zorro909.codecheck.config;
+
+public class ConfigException extends RuntimeException {
+
+    public ConfigException(String message) {
+        super(message);
+    }
+
+    public ConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/config/ConfigOverrides.java
+++ b/src/main/java/de/zorro909/codecheck/config/ConfigOverrides.java
@@ -1,0 +1,31 @@
+package de.zorro909.codecheck.config;
+
+import java.time.Duration;
+import java.util.List;
+
+public record ConfigOverrides(List<String> mainBranches,
+                              Duration inactivityTimeout,
+                              Duration saveDebounce) {
+
+    public static ConfigOverrides none() {
+        return new ConfigOverrides(null, null, null);
+    }
+
+    public CodeCheckConfig apply(CodeCheckConfig config) {
+        CodeCheckConfig result = config;
+        if (mainBranches != null) {
+            result = result.withGit(new CodeCheckConfig.Git(
+                    List.copyOf(mainBranches),
+                    result.git().releaseBranchPattern(),
+                    result.git().restageAfterFix()));
+        }
+        if (inactivityTimeout != null || saveDebounce != null) {
+            result = result.withDaemon(new CodeCheckConfig.Daemon(
+                    inactivityTimeout == null ? result.daemon().inactivityTimeout()
+                                              : inactivityTimeout,
+                    saveDebounce == null ? result.daemon().saveDebounce() : saveDebounce,
+                    result.daemon().transport()));
+        }
+        return result;
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/config/FileSystemCodeCheckConfigLoader.java
+++ b/src/main/java/de/zorro909/codecheck/config/FileSystemCodeCheckConfigLoader.java
@@ -1,8 +1,12 @@
 package de.zorro909.codecheck.config;
 
+import de.zorro909.codecheck.RepositoryPathProvider;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 import java.nio.file.Path;
+import java.util.function.Consumer;
 
 @Singleton
 public class FileSystemCodeCheckConfigLoader implements CodeCheckConfigLoader {
@@ -13,14 +17,21 @@ public class FileSystemCodeCheckConfigLoader implements CodeCheckConfigLoader {
     private final Path userConfig;
     private final CodeCheckConfigParser parser;
 
-    public FileSystemCodeCheckConfigLoader(Path repoDirectory) {
+    @Inject
+    public FileSystemCodeCheckConfigLoader(
+            @Named(RepositoryPathProvider.REPOSITORY_DIRECTORY) Path repoDirectory) {
         this(repoDirectory, defaultUserConfigPath());
     }
 
     public FileSystemCodeCheckConfigLoader(Path repoDirectory, Path userConfig) {
+        this(repoDirectory, userConfig, System.err::println);
+    }
+
+    public FileSystemCodeCheckConfigLoader(Path repoDirectory, Path userConfig,
+                                           Consumer<String> warningConsumer) {
         this.repoDirectory = repoDirectory.toAbsolutePath().normalize();
         this.userConfig = userConfig.toAbsolutePath().normalize();
-        this.parser = new CodeCheckConfigParser();
+        this.parser = new CodeCheckConfigParser(warningConsumer);
     }
 
     @Override

--- a/src/main/java/de/zorro909/codecheck/config/FileSystemCodeCheckConfigLoader.java
+++ b/src/main/java/de/zorro909/codecheck/config/FileSystemCodeCheckConfigLoader.java
@@ -1,0 +1,43 @@
+package de.zorro909.codecheck.config;
+
+import jakarta.inject.Singleton;
+
+import java.nio.file.Path;
+
+@Singleton
+public class FileSystemCodeCheckConfigLoader implements CodeCheckConfigLoader {
+
+    static final String REPO_CONFIG_FILE = ".codecheck.yaml";
+
+    private final Path repoDirectory;
+    private final Path userConfig;
+    private final CodeCheckConfigParser parser;
+
+    public FileSystemCodeCheckConfigLoader(Path repoDirectory) {
+        this(repoDirectory, defaultUserConfigPath());
+    }
+
+    public FileSystemCodeCheckConfigLoader(Path repoDirectory, Path userConfig) {
+        this.repoDirectory = repoDirectory.toAbsolutePath().normalize();
+        this.userConfig = userConfig.toAbsolutePath().normalize();
+        this.parser = new CodeCheckConfigParser();
+    }
+
+    @Override
+    public CodeCheckConfig load() {
+        return load(ConfigOverrides.none());
+    }
+
+    @Override
+    public CodeCheckConfig load(ConfigOverrides overrides) {
+        CodeCheckConfig config = CodeCheckConfig.defaults();
+        config = parser.applyIfPresent(userConfig, config);
+        config = parser.applyIfPresent(repoDirectory.resolve(REPO_CONFIG_FILE), config);
+        return overrides.apply(config);
+    }
+
+    private static Path defaultUserConfigPath() {
+        return Path.of(System.getProperty("user.home"), ".config", "git-commit-code-check",
+                       "config.yaml");
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/command/CodeCheckCommandServiceTest.java
+++ b/src/test/java/de/zorro909/codecheck/command/CodeCheckCommandServiceTest.java
@@ -6,6 +6,10 @@ import de.zorro909.codecheck.actions.FixAction;
 import de.zorro909.codecheck.actions.PostAction;
 import de.zorro909.codecheck.checks.CodeCheck;
 import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.config.CodeCheckConfig;
+import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import de.zorro909.codecheck.config.ConfigException;
+import de.zorro909.codecheck.config.ConfigOverrides;
 import de.zorro909.codecheck.selector.FileSelector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,6 +75,27 @@ class CodeCheckCommandServiceTest {
         assertThat(outcome.exitCode()).isEqualTo(1);
         assertThat(errorOutput()).contains("Failed to start or attach to assistant daemon")
                                  .contains("port is already in use");
+    }
+
+    @Test
+    void invalidConfigPreventsDaemonStartup() {
+        CodeCheckCommandService service = createService(Stream::empty, new CodeCheckConfigLoader() {
+            @Override
+            public CodeCheckConfig load() {
+                throw new ConfigException("Invalid config repo/.codecheck.yaml at git: expected");
+            }
+
+            @Override
+            public CodeCheckConfig load(ConfigOverrides overrides) {
+                throw new ConfigException("Invalid config repo/.codecheck.yaml at git: expected");
+            }
+        });
+
+        CommandOutcome outcome = service.startAssistantDaemon();
+
+        assertThat(outcome.exitCode()).isEqualTo(1);
+        assertThat(daemonController.startCalls).isZero();
+        assertThat(errorOutput()).contains("Invalid config repo/.codecheck.yaml at git");
     }
 
     @Test
@@ -193,7 +218,13 @@ class CodeCheckCommandServiceTest {
     }
 
     private CodeCheckCommandService createService(FileSelector fileSelector) {
+        return createService(fileSelector, CodeCheckConfigLoader.defaultsOnly());
+    }
+
+    private CodeCheckCommandService createService(FileSelector fileSelector,
+                                                 CodeCheckConfigLoader configLoader) {
         return new CodeCheckCommandService(daemonController, pipeline, fileSelector,
+                                           configLoader,
                                            new PrintStream(stdout, true, StandardCharsets.UTF_8),
                                            new PrintStream(stderr, true, StandardCharsets.UTF_8));
     }

--- a/src/test/java/de/zorro909/codecheck/config/FileSystemCodeCheckConfigLoaderBeanTest.java
+++ b/src/test/java/de/zorro909/codecheck/config/FileSystemCodeCheckConfigLoaderBeanTest.java
@@ -1,0 +1,18 @@
+package de.zorro909.codecheck.config;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileSystemCodeCheckConfigLoaderBeanTest {
+
+    @Test
+    void configLoaderBeanResolvesToFileSystemLoader() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            CodeCheckConfigLoader loader = context.getBean(CodeCheckConfigLoader.class);
+
+            assertThat(loader).isInstanceOf(FileSystemCodeCheckConfigLoader.class);
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/config/FileSystemCodeCheckConfigLoaderTest.java
+++ b/src/test/java/de/zorro909/codecheck/config/FileSystemCodeCheckConfigLoaderTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +19,7 @@ class FileSystemCodeCheckConfigLoaderTest {
         CodeCheckConfig config = loader(tempDir).load();
 
         assertThat(config.git().mainBranches()).containsExactly("develop", "main", "master");
+        assertThat(config.git().releaseBranchPattern()).isEqualTo("release/.*");
         assertThat(config.daemon().inactivityTimeout()).isEqualTo(Duration.ofMinutes(30));
         assertThat(config.maven().docker().image()).isEqualTo("team/mvnd-jdk25:latest");
     }
@@ -55,7 +57,7 @@ class FileSystemCodeCheckConfigLoaderTest {
         CodeCheckConfig config = loader(repo, userConfig).load();
 
         assertThat(config.git().mainBranches()).containsExactly("trunk", "main");
-        assertThat(config.git().releaseBranchPattern().pattern()).isEqualTo("release/.+");
+        assertThat(config.git().releaseBranchPattern()).isEqualTo("release/.+");
     }
 
     @Test
@@ -118,6 +120,21 @@ class FileSystemCodeCheckConfigLoaderTest {
     }
 
     @Test
+    void invalidReleaseBranchPatternFailsWithFieldPath(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+        Files.writeString(repo.resolve(".codecheck.yaml"), """
+                git:
+                  releaseBranchPattern: "release/["
+                """);
+
+        assertThatThrownBy(() -> loader(repo).load())
+                .isInstanceOf(ConfigException.class)
+                .hasMessageContaining("git.releaseBranchPattern")
+                .hasMessageContaining("invalid regular expression");
+    }
+
+    @Test
     void unknownEnumValueFailsWithFieldPath(@TempDir Path tempDir) throws Exception {
         Path repo = tempDir.resolve("repo");
         Files.createDirectories(repo);
@@ -130,6 +147,51 @@ class FileSystemCodeCheckConfigLoaderTest {
                 .isInstanceOf(ConfigException.class)
                 .hasMessageContaining("maven.runner")
                 .hasMessageContaining("unknown value");
+    }
+
+    @Test
+    void unknownConfigKeysProduceWarnings(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+        Files.writeString(repo.resolve(".codecheck.yaml"), """
+                git:
+                  mainbranches: [trunk]
+                unknownSection:
+                  foo: bar
+                """);
+        List<String> warnings = new ArrayList<>();
+        FileSystemCodeCheckConfigLoader loader = new FileSystemCodeCheckConfigLoader(
+                repo, repo.resolve("missing-user.yaml"), warnings::add);
+
+        CodeCheckConfig config = loader.load();
+
+        assertThat(config.git().mainBranches()).containsExactly("develop", "main", "master");
+        assertThat(warnings).anySatisfy(warning -> assertThat(warning)
+                .contains(".codecheck.yaml")
+                .contains("git")
+                .contains("unknown key 'mainbranches'"));
+        assertThat(warnings).anySatisfy(warning -> assertThat(warning)
+                .contains("unknown key 'unknownSection'"));
+    }
+
+    @Test
+    void knownConfigKeysProduceNoWarnings(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+        Files.writeString(repo.resolve(".codecheck.yaml"), """
+                git:
+                  mainBranches: [trunk]
+                maven:
+                  docker:
+                    image: "example/mvnd:jdk25"
+                """);
+        List<String> warnings = new ArrayList<>();
+        FileSystemCodeCheckConfigLoader loader = new FileSystemCodeCheckConfigLoader(
+                repo, repo.resolve("missing-user.yaml"), warnings::add);
+
+        loader.load();
+
+        assertThat(warnings).isEmpty();
     }
 
     private FileSystemCodeCheckConfigLoader loader(Path repo) {

--- a/src/test/java/de/zorro909/codecheck/config/FileSystemCodeCheckConfigLoaderTest.java
+++ b/src/test/java/de/zorro909/codecheck/config/FileSystemCodeCheckConfigLoaderTest.java
@@ -1,0 +1,142 @@
+package de.zorro909.codecheck.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FileSystemCodeCheckConfigLoaderTest {
+
+    @Test
+    void missingConfigFilesReturnDefaults(@TempDir Path tempDir) {
+        CodeCheckConfig config = loader(tempDir).load();
+
+        assertThat(config.git().mainBranches()).containsExactly("develop", "main", "master");
+        assertThat(config.daemon().inactivityTimeout()).isEqualTo(Duration.ofMinutes(30));
+        assertThat(config.maven().docker().image()).isEqualTo("team/mvnd-jdk25:latest");
+    }
+
+    @Test
+    void userConfigOverridesDefaults(@TempDir Path tempDir) throws Exception {
+        Path userConfig = tempDir.resolve("user.yaml");
+        Files.writeString(userConfig, """
+                daemon:
+                  inactivityTimeout: "45m"
+                  saveDebounce: "2s"
+                """);
+
+        CodeCheckConfig config = loader(tempDir.resolve("repo"), userConfig).load();
+
+        assertThat(config.daemon().inactivityTimeout()).isEqualTo(Duration.ofMinutes(45));
+        assertThat(config.daemon().saveDebounce()).isEqualTo(Duration.ofSeconds(2));
+    }
+
+    @Test
+    void repoConfigOverridesUserConfig(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+        Path userConfig = tempDir.resolve("user.yaml");
+        Files.writeString(userConfig, """
+                git:
+                  mainBranches: [main]
+                """);
+        Files.writeString(repo.resolve(".codecheck.yaml"), """
+                git:
+                  mainBranches: [trunk, main]
+                  releaseBranchPattern: "release/.+"
+                """);
+
+        CodeCheckConfig config = loader(repo, userConfig).load();
+
+        assertThat(config.git().mainBranches()).containsExactly("trunk", "main");
+        assertThat(config.git().releaseBranchPattern().pattern()).isEqualTo("release/.+");
+    }
+
+    @Test
+    void repoConfigSetsMavenGoalsAndDockerImage(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+        Files.writeString(repo.resolve(".codecheck.yaml"), """
+                maven:
+                  goals: ["verify", "jacoco:report"]
+                  args: ["-DskipITs"]
+                  targetedTestProperty: "-Dit.test"
+                  docker:
+                    image: "example/mvnd:jdk25"
+                    containerIdleTimeout: "90s"
+                    mountM2: false
+                """);
+
+        CodeCheckConfig config = loader(repo).load();
+
+        assertThat(config.maven().goals()).containsExactly("verify", "jacoco:report");
+        assertThat(config.maven().args()).containsExactly("-DskipITs");
+        assertThat(config.maven().targetedTestProperty()).isEqualTo("-Dit.test");
+        assertThat(config.maven().docker().image()).isEqualTo("example/mvnd:jdk25");
+        assertThat(config.maven().docker().containerIdleTimeout()).isEqualTo(Duration.ofSeconds(90));
+        assertThat(config.maven().docker().mountM2()).isFalse();
+    }
+
+    @Test
+    void cliOverridesWinOverFileConfig(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+        Files.writeString(repo.resolve(".codecheck.yaml"), """
+                git:
+                  mainBranches: [develop]
+                daemon:
+                  saveDebounce: "10s"
+                """);
+
+        CodeCheckConfig config = loader(repo).load(new ConfigOverrides(
+                List.of("release-main"), null, Duration.ofMillis(250)));
+
+        assertThat(config.git().mainBranches()).containsExactly("release-main");
+        assertThat(config.daemon().saveDebounce()).isEqualTo(Duration.ofMillis(250));
+    }
+
+    @Test
+    void invalidConfigFailsWithActionableFieldPath(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+        Files.writeString(repo.resolve(".codecheck.yaml"), """
+                daemon:
+                  saveDebounce: "soon"
+                """);
+
+        assertThatThrownBy(() -> loader(repo).load())
+                .isInstanceOf(ConfigException.class)
+                .hasMessageContaining(".codecheck.yaml")
+                .hasMessageContaining("daemon.saveDebounce")
+                .hasMessageContaining("invalid duration");
+    }
+
+    @Test
+    void unknownEnumValueFailsWithFieldPath(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+        Files.writeString(repo.resolve(".codecheck.yaml"), """
+                maven:
+                  runner: host-maven
+                """);
+
+        assertThatThrownBy(() -> loader(repo).load())
+                .isInstanceOf(ConfigException.class)
+                .hasMessageContaining("maven.runner")
+                .hasMessageContaining("unknown value");
+    }
+
+    private FileSystemCodeCheckConfigLoader loader(Path repo) {
+        return loader(repo, repo.resolve("missing-user.yaml"));
+    }
+
+    private FileSystemCodeCheckConfigLoader loader(Path repo, Path userConfig) {
+        return new FileSystemCodeCheckConfigLoader(repo, userConfig);
+    }
+}


### PR DESCRIPTION
## Summary
- add the CR-002 implementation specification
- introduce typed config defaults for git, daemon, java, maven, Docker, and coverage settings
- load optional user and repo YAML with precedence defaults < user < repo < CLI overrides
- fail command execution early on invalid config diagnostics

## Tests
- ./mvnw test