### PR TITLE
CR-003: Daemon lifecycle and transport metadata

### DIFF
--- a/docs/implementation-specs/CR-003-daemon-lifecycle-and-transport.md
+++ b/docs/implementation-specs/CR-003-daemon-lifecycle-and-transport.md
@@ -1,0 +1,58 @@
+# CR-003 Implementation Specification: Daemon Lifecycle and Transport
+
+## Scope
+
+This increment makes daemon lifecycle state explicit and per repository. It introduces stable
+repository identity, cache metadata, dynamic localhost ports, local auth tokens, stale metadata
+cleanup, attach-if-alive command behavior, and inactivity shutdown. The current transport remains
+the existing JDK local server behind daemon metadata; the metadata uses the target `websocket`
+transport name so the CR-003 WebSocket transport can replace the control server without changing
+registry or command flow.
+
+## Runtime Metadata
+
+Metadata is stored under:
+
+```text
+~/.cache/git-commit-code-check/repos/<repo-id>/
+  daemon.json
+  daemon.pid
+```
+
+`repo-id` is a SHA-256 hash of the canonical repository path. The raw path is not used as a cache
+directory name.
+
+## Startup
+
+1. Resolve current repository directory.
+2. Compute the repository id and metadata path.
+3. Read existing metadata.
+4. If the recorded process is alive, treat the daemon as attached and return silently.
+5. If metadata is stale, remove it.
+6. Allocate a random localhost port and auth token.
+7. Write metadata and start the daemon server.
+8. If startup fails, remove metadata and print the failure through the command service.
+
+## Transport Control
+
+The server binds to `127.0.0.1` and a random available port. Control endpoints require the
+`X-CodeCheck-Token` header:
+
+- `GET /health`
+- `GET /check`
+- `POST /shutdown`
+
+Unauthorized requests return `401`.
+
+## Inactivity
+
+The daemon receives the configured inactivity timeout. Authorized control requests and file updates
+refresh activity. When idle time exceeds the timeout, the server stops.
+
+## Tests
+
+- Repository ids are stable hashes and metadata paths do not expose raw repository paths.
+- Alive metadata is loaded and stale metadata is cleaned.
+- New metadata uses localhost, a random port, a non-empty token, and writes `daemon.json` plus
+  `daemon.pid`.
+- Control endpoints reject missing tokens and accept the correct token.

--- a/docs/implementation-specs/CR-003-daemon-lifecycle-and-transport.md
+++ b/docs/implementation-specs/CR-003-daemon-lifecycle-and-transport.md
@@ -42,7 +42,11 @@ The server binds to `127.0.0.1` and a random available port. Control endpoints r
 - `GET /check`
 - `POST /shutdown`
 
-Unauthorized requests return `401`.
+Unauthorized requests return `401`. An empty token never authorizes; a daemon cannot run without
+authentication.
+
+On POSIX file systems the metadata directory and files are readable and writable only by the
+owning user, so the auth token is not exposed to other local users.
 
 ## Inactivity
 
@@ -56,3 +60,6 @@ refresh activity. When idle time exceeds the timeout, the server stops.
 - New metadata uses localhost, a random port, a non-empty token, and writes `daemon.json` plus
   `daemon.pid`.
 - Control endpoints reject missing tokens and accept the correct token.
+- Empty-token metadata rejects every request.
+- Metadata files are owner-only on POSIX file systems.
+- The registry bean resolves through the qualified repository directory path.

--- a/src/main/java/de/zorro909/codecheck/command/LocalAssistantDaemonController.java
+++ b/src/main/java/de/zorro909/codecheck/command/LocalAssistantDaemonController.java
@@ -1,6 +1,10 @@
 package de.zorro909.codecheck.command;
 
+import de.zorro909.codecheck.config.CodeCheckConfig;
+import de.zorro909.codecheck.config.CodeCheckConfigLoader;
 import de.zorro909.codecheck.daemon.DaemonServer;
+import de.zorro909.codecheck.daemon.DaemonMetadata;
+import de.zorro909.codecheck.daemon.DaemonProcessRegistry;
 import jakarta.inject.Singleton;
 
 import java.io.PrintStream;
@@ -9,19 +13,42 @@ import java.io.PrintStream;
 public class LocalAssistantDaemonController implements AssistantDaemonController {
 
     private final DaemonServer daemonServer;
+    private final DaemonProcessRegistry daemonProcessRegistry;
+    private final CodeCheckConfigLoader configLoader;
 
-    public LocalAssistantDaemonController(DaemonServer daemonServer) {
+    public LocalAssistantDaemonController(DaemonServer daemonServer,
+                                          DaemonProcessRegistry daemonProcessRegistry,
+                                          CodeCheckConfigLoader configLoader) {
         this.daemonServer = daemonServer;
+        this.daemonProcessRegistry = daemonProcessRegistry;
+        this.configLoader = configLoader;
     }
 
     @Override
     public void startOrAttach() throws Exception {
-        daemonServer.run();
+        if (daemonProcessRegistry.aliveMetadata().isPresent()) {
+            return;
+        }
+
+        CodeCheckConfig config = configLoader.load();
+        DaemonMetadata metadata = daemonProcessRegistry.createMetadata();
+        daemonProcessRegistry.write(metadata);
+        try {
+            daemonServer.run(metadata, config.daemon().inactivityTimeout());
+        } catch (Exception e) {
+            daemonProcessRegistry.clear();
+            throw e;
+        }
     }
 
     @Override
     public void printStatus(PrintStream out) {
-        out.println("Assistant daemon status is not available yet.");
+        daemonProcessRegistry.aliveMetadata()
+                             .ifPresentOrElse(
+                                     metadata -> out.println("Assistant daemon running on "
+                                                             + metadata.host() + ":"
+                                                             + metadata.port()),
+                                     () -> out.println("Assistant daemon is not running."));
     }
 
     @Override

--- a/src/main/java/de/zorro909/codecheck/daemon/DaemonMetadata.java
+++ b/src/main/java/de/zorro909/codecheck/daemon/DaemonMetadata.java
@@ -1,0 +1,13 @@
+package de.zorro909.codecheck.daemon;
+
+import java.nio.file.Path;
+import java.time.Instant;
+
+public record DaemonMetadata(long pid,
+                             Path repoRoot,
+                             String transport,
+                             String host,
+                             int port,
+                             String token,
+                             Instant startedAt) {
+}

--- a/src/main/java/de/zorro909/codecheck/daemon/DaemonMetadataStore.java
+++ b/src/main/java/de/zorro909/codecheck/daemon/DaemonMetadataStore.java
@@ -1,0 +1,116 @@
+package de.zorro909.codecheck.daemon;
+
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+final class DaemonMetadataStore {
+
+    private static final String DAEMON_JSON = "daemon.json";
+    private static final String DAEMON_PID = "daemon.pid";
+
+    private final Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+
+    Optional<DaemonMetadata> read(Path metadataDirectory) {
+        Path metadataFile = metadataDirectory.resolve(DAEMON_JSON);
+        if (!Files.exists(metadataFile)) {
+            return Optional.empty();
+        }
+
+        try (Reader reader = Files.newBufferedReader(metadataFile)) {
+            Object loaded = yaml.load(reader);
+            if (!(loaded instanceof Map<?, ?> values)) {
+                return Optional.empty();
+            }
+            return Optional.of(new DaemonMetadata(
+                    number(values, "pid").longValue(),
+                    Path.of(string(values, "repoRoot")),
+                    string(values, "transport"),
+                    string(values, "host"),
+                    number(values, "port").intValue(),
+                    string(values, "token"),
+                    Instant.parse(string(values, "startedAt"))));
+        } catch (RuntimeException | IOException e) {
+            delete(metadataDirectory);
+            return Optional.empty();
+        }
+    }
+
+    void write(Path metadataDirectory, DaemonMetadata metadata) {
+        try {
+            Files.createDirectories(metadataDirectory);
+            Files.writeString(metadataDirectory.resolve(DAEMON_JSON), toJson(metadata),
+                              StandardCharsets.UTF_8);
+            Files.writeString(metadataDirectory.resolve(DAEMON_PID),
+                              Long.toString(metadata.pid()), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to write daemon metadata", e);
+        }
+    }
+
+    void delete(Path metadataDirectory) {
+        if (!Files.exists(metadataDirectory)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(metadataDirectory)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(this::deletePath);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to delete daemon metadata", e);
+        }
+    }
+
+    private void deletePath(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to delete " + path, e);
+        }
+    }
+
+    private String toJson(DaemonMetadata metadata) {
+        return """
+                {
+                  "pid": %d,
+                  "repoRoot": "%s",
+                  "transport": "%s",
+                  "host": "%s",
+                  "port": %d,
+                  "token": "%s",
+                  "startedAt": "%s"
+                }
+                """.formatted(metadata.pid(), escape(metadata.repoRoot().toString()),
+                               escape(metadata.transport()), escape(metadata.host()),
+                               metadata.port(), escape(metadata.token()), metadata.startedAt());
+    }
+
+    private String escape(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private Number number(Map<?, ?> values, String key) {
+        Object value = values.get(key);
+        if (value instanceof Number number) {
+            return number;
+        }
+        throw new IllegalArgumentException("Missing numeric metadata field " + key);
+    }
+
+    private String string(Map<?, ?> values, String key) {
+        Object value = values.get(key);
+        if (value instanceof String string) {
+            return string;
+        }
+        throw new IllegalArgumentException("Missing string metadata field " + key);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/daemon/DaemonMetadataStore.java
+++ b/src/main/java/de/zorro909/codecheck/daemon/DaemonMetadataStore.java
@@ -7,18 +7,26 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 final class DaemonMetadataStore {
 
     private static final String DAEMON_JSON = "daemon.json";
     private static final String DAEMON_PID = "daemon.pid";
+    private static final boolean POSIX_PERMISSIONS_SUPPORTED = FileSystems.getDefault()
+            .supportedFileAttributeViews()
+            .contains("posix");
 
     private final Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
 
@@ -49,14 +57,34 @@ final class DaemonMetadataStore {
 
     void write(Path metadataDirectory, DaemonMetadata metadata) {
         try {
-            Files.createDirectories(metadataDirectory);
-            Files.writeString(metadataDirectory.resolve(DAEMON_JSON), toJson(metadata),
-                              StandardCharsets.UTF_8);
-            Files.writeString(metadataDirectory.resolve(DAEMON_PID),
-                              Long.toString(metadata.pid()), StandardCharsets.UTF_8);
+            createOwnerOnlyDirectories(metadataDirectory);
+            writeOwnerOnly(metadataDirectory.resolve(DAEMON_JSON), toJson(metadata));
+            writeOwnerOnly(metadataDirectory.resolve(DAEMON_PID),
+                           Long.toString(metadata.pid()));
         } catch (IOException e) {
             throw new IllegalStateException("Unable to write daemon metadata", e);
         }
+    }
+
+    private void createOwnerOnlyDirectories(Path directory) throws IOException {
+        if (!POSIX_PERMISSIONS_SUPPORTED) {
+            Files.createDirectories(directory);
+            return;
+        }
+        Set<PosixFilePermission> ownerOnly = PosixFilePermissions.fromString("rwx------");
+        FileAttribute<Set<PosixFilePermission>> attribute =
+                PosixFilePermissions.asFileAttribute(ownerOnly);
+        Files.createDirectories(directory, attribute);
+        Files.setPosixFilePermissions(directory, ownerOnly);
+    }
+
+    private void writeOwnerOnly(Path file, String content) throws IOException {
+        if (POSIX_PERMISSIONS_SUPPORTED) {
+            Files.deleteIfExists(file);
+            Files.createFile(file, PosixFilePermissions.asFileAttribute(
+                    PosixFilePermissions.fromString("rw-------")));
+        }
+        Files.writeString(file, content, StandardCharsets.UTF_8);
     }
 
     void delete(Path metadataDirectory) {

--- a/src/main/java/de/zorro909/codecheck/daemon/DaemonProcessRegistry.java
+++ b/src/main/java/de/zorro909/codecheck/daemon/DaemonProcessRegistry.java
@@ -1,5 +1,8 @@
 package de.zorro909.codecheck.daemon;
 
+import de.zorro909.codecheck.RepositoryPathProvider;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 import java.io.IOException;
@@ -26,7 +29,9 @@ public class DaemonProcessRegistry {
     private final DaemonMetadataStore metadataStore;
     private final SecureRandom secureRandom = new SecureRandom();
 
-    public DaemonProcessRegistry(Path repositoryDirectory) {
+    @Inject
+    public DaemonProcessRegistry(
+            @Named(RepositoryPathProvider.REPOSITORY_DIRECTORY) Path repositoryDirectory) {
         this(repositoryDirectory, defaultCacheRoot());
     }
 

--- a/src/main/java/de/zorro909/codecheck/daemon/DaemonProcessRegistry.java
+++ b/src/main/java/de/zorro909/codecheck/daemon/DaemonProcessRegistry.java
@@ -1,0 +1,98 @@
+package de.zorro909.codecheck.daemon;
+
+import jakarta.inject.Singleton;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.Optional;
+
+@Singleton
+public class DaemonProcessRegistry {
+
+    static final String TRANSPORT_WEBSOCKET = "websocket";
+    private static final String HOST = "127.0.0.1";
+
+    private final Path repositoryDirectory;
+    private final Path cacheRoot;
+    private final DaemonMetadataStore metadataStore;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public DaemonProcessRegistry(Path repositoryDirectory) {
+        this(repositoryDirectory, defaultCacheRoot());
+    }
+
+    public DaemonProcessRegistry(Path repositoryDirectory, Path cacheRoot) {
+        this.repositoryDirectory = repositoryDirectory.toAbsolutePath().normalize();
+        this.cacheRoot = cacheRoot.toAbsolutePath().normalize();
+        this.metadataStore = new DaemonMetadataStore();
+    }
+
+    public String repoId() {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(repositoryDirectory.toString()
+                                                           .getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    public Path metadataDirectory() {
+        return cacheRoot.resolve("repos").resolve(repoId());
+    }
+
+    public Optional<DaemonMetadata> aliveMetadata() {
+        Optional<DaemonMetadata> metadata = metadataStore.read(metadataDirectory());
+        if (metadata.isEmpty()) {
+            return Optional.empty();
+        }
+        if (ProcessHandle.of(metadata.get().pid()).filter(ProcessHandle::isAlive).isPresent()) {
+            return metadata;
+        }
+        clear();
+        return Optional.empty();
+    }
+
+    public DaemonMetadata createMetadata() {
+        return new DaemonMetadata(ProcessHandle.current().pid(), repositoryDirectory,
+                                  TRANSPORT_WEBSOCKET, HOST, randomPort(), randomToken(),
+                                  Instant.now());
+    }
+
+    public void write(DaemonMetadata metadata) {
+        metadataStore.write(metadataDirectory(), metadata);
+    }
+
+    public void clear() {
+        metadataStore.delete(metadataDirectory());
+    }
+
+    private int randomPort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to allocate daemon port", e);
+        }
+    }
+
+    private String randomToken() {
+        byte[] bytes = new byte[32];
+        secureRandom.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private static Path defaultCacheRoot() {
+        return Path.of(System.getProperty("user.home"), ".cache", "git-commit-code-check");
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/daemon/DaemonServer.java
+++ b/src/main/java/de/zorro909/codecheck/daemon/DaemonServer.java
@@ -46,17 +46,14 @@ public class DaemonServer {
     }
 
     /**
-     * Runs the application by selecting files, updating files, starting an HTTP server, and running the server indefinitely.
+     * Starts the daemon control server described by the metadata and blocks until it is shut
+     * down via the control endpoint or the inactivity timeout elapses.
      *
-     * @throws IOException            if an I/O error occurs during the file selection process.
-     * @throws InterruptedException   if the current thread is interrupted while sleeping.
+     * @param metadata          host, port, and auth token the server binds and authorizes with.
+     * @param inactivityTimeout idle time after which the server stops itself.
+     * @throws IOException          if the server cannot bind to the configured address.
+     * @throws InterruptedException if the current thread is interrupted while waiting.
      */
-    public void run() throws IOException, InterruptedException {
-        run(new DaemonMetadata(ProcessHandle.current().pid(), Path.of(""),
-                               DaemonProcessRegistry.TRANSPORT_WEBSOCKET, "127.0.0.1", 23464,
-                               "", Instant.now()), Duration.ofMinutes(30));
-    }
-
     public void run(DaemonMetadata metadata, Duration inactivityTimeout)
             throws IOException, InterruptedException {
         CountDownLatch shutdownLatch = new CountDownLatch(1);
@@ -108,8 +105,8 @@ public class DaemonServer {
 
     private void handleAuthorized(DaemonMetadata metadata, HttpExchange httpExchange,
                                   ThrowingRunnable handler) throws IOException {
-        if (!metadata.token().isEmpty()
-            && !metadata.token().equals(httpExchange.getRequestHeaders()
+        if (metadata.token().isEmpty()
+            || !metadata.token().equals(httpExchange.getRequestHeaders()
                                                     .getFirst("X-CodeCheck-Token"))) {
             sendResponse(httpExchange, 401, "Unauthorized");
             return;

--- a/src/main/java/de/zorro909/codecheck/daemon/DaemonServer.java
+++ b/src/main/java/de/zorro909/codecheck/daemon/DaemonServer.java
@@ -12,11 +12,17 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -31,6 +37,7 @@ public class DaemonServer {
 
     private final Map<Path, Set<Path>> fileDependencies = new HashMap<>();
     private Path currentFile;
+    private final AtomicReference<Instant> lastActivity = new AtomicReference<>(Instant.now());
 
     public DaemonServer(FileSelector fileSelector,
                         Provider<ValidationCheckPipeline> validationCheckPipeline) {
@@ -45,24 +52,85 @@ public class DaemonServer {
      * @throws InterruptedException   if the current thread is interrupted while sleeping.
      */
     public void run() throws IOException, InterruptedException {
-        HttpServer server = getHttpServer();
-        server.start();
-        runServerIndefinitely();
+        run(new DaemonMetadata(ProcessHandle.current().pid(), Path.of(""),
+                               DaemonProcessRegistry.TRANSPORT_WEBSOCKET, "127.0.0.1", 23464,
+                               "", Instant.now()), Duration.ofMinutes(30));
     }
 
-    private HttpServer getHttpServer() throws IOException {
-        HttpServer server = HttpServer.create(new InetSocketAddress(23464), 4);
+    public void run(DaemonMetadata metadata, Duration inactivityTimeout)
+            throws IOException, InterruptedException {
+        CountDownLatch shutdownLatch = new CountDownLatch(1);
+        HttpServer server = getHttpServer(metadata, shutdownLatch);
+        ScheduledExecutorService idleMonitor = startIdleMonitor(server, shutdownLatch,
+                                                                inactivityTimeout);
+        server.start();
+        try {
+            shutdownLatch.await();
+        } finally {
+            idleMonitor.shutdownNow();
+            server.stop(0);
+        }
+    }
+
+    private HttpServer getHttpServer(DaemonMetadata metadata, CountDownLatch shutdownLatch)
+            throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(metadata.host(),
+                                                                    metadata.port()), 4);
         server.setExecutor(Executors.newVirtualThreadPerTaskExecutor());
-        server.createContext("/check", this::handleHttpExchange);
+        server.createContext("/health",
+                             httpExchange -> handleAuthorized(metadata, httpExchange,
+                                                              () -> sendResponse(httpExchange,
+                                                                                 204, "")));
+        server.createContext("/check",
+                             httpExchange -> handleAuthorized(metadata, httpExchange,
+                                                              () -> handleCheck(httpExchange)));
+        server.createContext("/shutdown",
+                             httpExchange -> handleAuthorized(metadata, httpExchange, () -> {
+                                 sendResponse(httpExchange, 204, "");
+                                 shutdownLatch.countDown();
+                             }));
         return server;
     }
 
-    private void handleHttpExchange(HttpExchange httpExchange) throws IOException {
+    private ScheduledExecutorService startIdleMonitor(HttpServer server,
+                                                      CountDownLatch shutdownLatch,
+                                                      Duration inactivityTimeout) {
+        ScheduledExecutorService idleMonitor = Executors.newSingleThreadScheduledExecutor();
+        idleMonitor.scheduleAtFixedRate(() -> {
+            if (Duration.between(lastActivity.get(), Instant.now())
+                        .compareTo(inactivityTimeout) >= 0) {
+                server.stop(0);
+                shutdownLatch.countDown();
+            }
+        }, 1, 1, TimeUnit.SECONDS);
+        return idleMonitor;
+    }
+
+    private void handleAuthorized(DaemonMetadata metadata, HttpExchange httpExchange,
+                                  ThrowingRunnable handler) throws IOException {
+        if (!metadata.token().isEmpty()
+            && !metadata.token().equals(httpExchange.getRequestHeaders()
+                                                    .getFirst("X-CodeCheck-Token"))) {
+            sendResponse(httpExchange, 401, "Unauthorized");
+            return;
+        }
+        refreshActivity();
+        handler.run();
+    }
+
+    private void handleCheck(HttpExchange httpExchange) throws IOException {
         ValidationCheckPipeline vcp = validationCheckPipeline.get();
         String validationOutput = getValidationOutput(vcp);
-        byte[] response = validationOutput.getBytes(StandardCharsets.UTF_8);
-        httpExchange.sendResponseHeaders(200, response.length);
-        httpExchange.getResponseBody().write(response);
+        sendResponse(httpExchange, 200, validationOutput);
+    }
+
+    private void sendResponse(HttpExchange httpExchange, int statusCode, String body)
+            throws IOException {
+        byte[] response = body.getBytes(StandardCharsets.UTF_8);
+        httpExchange.sendResponseHeaders(statusCode, response.length == 0 ? -1 : response.length);
+        try (var responseBody = httpExchange.getResponseBody()) {
+            responseBody.write(response);
+        }
     }
 
     private String getValidationOutput(ValidationCheckPipeline vcp) throws IOException {
@@ -72,16 +140,6 @@ public class DaemonServer {
                            .orElse(Stream.empty())
                            .map(ValidationError::toString)
                            .collect(Collectors.joining("\n"));
-    }
-
-    private void runServerIndefinitely() {
-        while (true) {
-            try {
-                Thread.sleep(Long.MAX_VALUE);
-            } catch (InterruptedException e) {
-                System.err.println("Server interrupted: " + e.getMessage());
-            }
-        }
     }
 
     /**
@@ -103,6 +161,7 @@ public class DaemonServer {
      * @param path The path of the file to update.
      */
     public synchronized void updateFile(Path path) {
+        refreshActivity();
         if (fileDependencies.containsKey(path)) {
             fileDependencies.get(path).forEach(this::updateFile);
         }
@@ -111,5 +170,14 @@ public class DaemonServer {
                                .checkFile(path)
                                .map(ValidationError::toString)
                                .forEach(System.out::println);
+    }
+
+    private void refreshActivity() {
+        lastActivity.set(Instant.now());
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws IOException;
     }
 }

--- a/src/test/java/de/zorro909/codecheck/daemon/DaemonProcessRegistryBeanTest.java
+++ b/src/test/java/de/zorro909/codecheck/daemon/DaemonProcessRegistryBeanTest.java
@@ -1,0 +1,18 @@
+package de.zorro909.codecheck.daemon;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DaemonProcessRegistryBeanTest {
+
+    @Test
+    void registryBeanResolvesWithRepositoryDirectory() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            DaemonProcessRegistry registry = context.getBean(DaemonProcessRegistry.class);
+
+            assertThat(registry.repoId()).matches("[0-9a-f]{64}");
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/daemon/DaemonProcessRegistryTest.java
+++ b/src/test/java/de/zorro909/codecheck/daemon/DaemonProcessRegistryTest.java
@@ -3,11 +3,14 @@ package de.zorro909.codecheck.daemon;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class DaemonProcessRegistryTest {
 
@@ -42,6 +45,29 @@ class DaemonProcessRegistryTest {
         assertThat(loaded.get().token()).isNotBlank();
         assertThat(registry.metadataDirectory().resolve("daemon.json")).exists();
         assertThat(registry.metadataDirectory().resolve("daemon.pid")).exists();
+    }
+
+    @Test
+    void metadataFilesAreReadableOnlyByOwner(@TempDir Path tempDir) throws Exception {
+        assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+        DaemonProcessRegistry registry = new DaemonProcessRegistry(repo, tempDir.resolve("cache"));
+
+        registry.write(registry.createMetadata());
+
+        assertThat(Files.getPosixFilePermissions(registry.metadataDirectory()))
+                .containsExactlyInAnyOrder(PosixFilePermission.OWNER_READ,
+                                           PosixFilePermission.OWNER_WRITE,
+                                           PosixFilePermission.OWNER_EXECUTE);
+        assertThat(Files.getPosixFilePermissions(
+                registry.metadataDirectory().resolve("daemon.json")))
+                .containsExactlyInAnyOrder(PosixFilePermission.OWNER_READ,
+                                           PosixFilePermission.OWNER_WRITE);
+        assertThat(Files.getPosixFilePermissions(
+                registry.metadataDirectory().resolve("daemon.pid")))
+                .containsExactlyInAnyOrder(PosixFilePermission.OWNER_READ,
+                                           PosixFilePermission.OWNER_WRITE);
     }
 
     @Test

--- a/src/test/java/de/zorro909/codecheck/daemon/DaemonProcessRegistryTest.java
+++ b/src/test/java/de/zorro909/codecheck/daemon/DaemonProcessRegistryTest.java
@@ -1,0 +1,62 @@
+package de.zorro909.codecheck.daemon;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DaemonProcessRegistryTest {
+
+    @Test
+    void repoIdIsStableHashAndMetadataPathDoesNotExposeRawRepoName(@TempDir Path tempDir)
+            throws Exception {
+        Path repo = tempDir.resolve("repo with spaces");
+        Files.createDirectories(repo);
+        DaemonProcessRegistry first = new DaemonProcessRegistry(repo, tempDir.resolve("cache"));
+        DaemonProcessRegistry second = new DaemonProcessRegistry(repo, tempDir.resolve("cache"));
+
+        assertThat(first.repoId()).isEqualTo(second.repoId());
+        assertThat(first.repoId()).matches("[0-9a-f]{64}");
+        assertThat(first.metadataDirectory().getFileName().toString()).isEqualTo(first.repoId());
+        assertThat(first.metadataDirectory().toString()).doesNotContain("repo with spaces");
+    }
+
+    @Test
+    void writesAndReadsAliveMetadata(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+        DaemonProcessRegistry registry = new DaemonProcessRegistry(repo, tempDir.resolve("cache"));
+
+        DaemonMetadata metadata = registry.createMetadata();
+        registry.write(metadata);
+
+        Optional<DaemonMetadata> loaded = registry.aliveMetadata();
+        assertThat(loaded).isPresent();
+        assertThat(loaded.get().pid()).isEqualTo(ProcessHandle.current().pid());
+        assertThat(loaded.get().host()).isEqualTo("127.0.0.1");
+        assertThat(loaded.get().port()).isPositive();
+        assertThat(loaded.get().token()).isNotBlank();
+        assertThat(registry.metadataDirectory().resolve("daemon.json")).exists();
+        assertThat(registry.metadataDirectory().resolve("daemon.pid")).exists();
+    }
+
+    @Test
+    void staleMetadataIsCleaned(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+        DaemonProcessRegistry registry = new DaemonProcessRegistry(repo, tempDir.resolve("cache"));
+        DaemonMetadata stale = new DaemonMetadata(Long.MAX_VALUE, repo, "websocket",
+                                                  "127.0.0.1", 49152, "token",
+                                                  java.time.Instant.now());
+        registry.write(stale);
+
+        Optional<DaemonMetadata> loaded = registry.aliveMetadata();
+
+        assertThat(loaded).isEmpty();
+        assertThat(registry.metadataDirectory()).doesNotExist();
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/daemon/DaemonServerTest.java
+++ b/src/test/java/de/zorro909/codecheck/daemon/DaemonServerTest.java
@@ -51,6 +51,56 @@ class DaemonServerTest {
         }
     }
 
+    @Test
+    void emptyTokenMetadataRejectsAllRequests(@TempDir Path tempDir) throws Exception {
+        DaemonProcessRegistry registry = new DaemonProcessRegistry(tempDir.resolve("repo"),
+                                                                   tempDir.resolve("cache"));
+        DaemonMetadata withToken = registry.createMetadata();
+        DaemonMetadata metadata = new DaemonMetadata(withToken.pid(), withToken.repoRoot(),
+                                                     withToken.transport(), withToken.host(),
+                                                     withToken.port(), "",
+                                                     withToken.startedAt());
+        DaemonServer server = new DaemonServer(emptySelector(), emptyPipelineProvider());
+        Thread serverThread = Thread.ofVirtual().start(() -> run(server, metadata));
+        try {
+            URI healthUri = URI.create("http://" + metadata.host() + ":" + metadata.port()
+                                       + "/health");
+            waitUntilResponding(healthUri);
+
+            HttpClient client = HttpClient.newHttpClient();
+            HttpResponse<String> withoutHeader = client.send(
+                    HttpRequest.newBuilder(healthUri).GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> withEmptyHeader = client.send(
+                    HttpRequest.newBuilder(healthUri)
+                               .header("X-CodeCheck-Token", "")
+                               .GET()
+                               .build(),
+                    HttpResponse.BodyHandlers.ofString());
+
+            assertThat(withoutHeader.statusCode()).isEqualTo(401);
+            assertThat(withEmptyHeader.statusCode()).isEqualTo(401);
+        } finally {
+            serverThread.interrupt();
+            serverThread.join(Duration.ofSeconds(5));
+        }
+    }
+
+    private void waitUntilResponding(URI healthUri) throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        Instant deadline = Instant.now().plusSeconds(5);
+        while (Instant.now().isBefore(deadline)) {
+            try {
+                client.send(HttpRequest.newBuilder(healthUri).GET().build(),
+                            HttpResponse.BodyHandlers.ofString());
+                return;
+            } catch (Exception ignored) {
+                Thread.sleep(50);
+            }
+        }
+        throw new AssertionError("Daemon server did not become ready");
+    }
+
     private void run(DaemonServer server, DaemonMetadata metadata) {
         try {
             server.run(metadata, Duration.ofMinutes(5));

--- a/src/test/java/de/zorro909/codecheck/daemon/DaemonServerTest.java
+++ b/src/test/java/de/zorro909/codecheck/daemon/DaemonServerTest.java
@@ -1,0 +1,114 @@
+package de.zorro909.codecheck.daemon;
+
+import de.zorro909.codecheck.ValidationCheckPipeline;
+import de.zorro909.codecheck.selector.FileSelector;
+import jakarta.inject.Provider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DaemonServerTest {
+
+    @Test
+    void controlEndpointsRequireToken(@TempDir Path tempDir) throws Exception {
+        DaemonProcessRegistry registry = new DaemonProcessRegistry(tempDir.resolve("repo"),
+                                                                   tempDir.resolve("cache"));
+        DaemonMetadata metadata = registry.createMetadata();
+        DaemonServer server = new DaemonServer(emptySelector(), emptyPipelineProvider());
+        Thread serverThread = Thread.ofVirtual().start(() -> run(server, metadata));
+        try {
+            URI healthUri = URI.create("http://" + metadata.host() + ":" + metadata.port()
+                                       + "/health");
+            waitUntilReady(healthUri, metadata.token());
+
+            HttpClient client = HttpClient.newHttpClient();
+            HttpResponse<String> unauthorized = client.send(
+                    HttpRequest.newBuilder(healthUri).GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> authorized = client.send(
+                    HttpRequest.newBuilder(healthUri)
+                               .header("X-CodeCheck-Token", metadata.token())
+                               .GET()
+                               .build(),
+                    HttpResponse.BodyHandlers.ofString());
+
+            assertThat(unauthorized.statusCode()).isEqualTo(401);
+            assertThat(authorized.statusCode()).isEqualTo(204);
+        } finally {
+            shutdown(metadata);
+            serverThread.join(Duration.ofSeconds(5));
+        }
+    }
+
+    private void run(DaemonServer server, DaemonMetadata metadata) {
+        try {
+            server.run(metadata, Duration.ofMinutes(5));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void waitUntilReady(URI healthUri, String token) throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        Instant deadline = Instant.now().plusSeconds(5);
+        while (Instant.now().isBefore(deadline)) {
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(healthUri)
+                                   .header("X-CodeCheck-Token", token)
+                                   .GET()
+                                   .build(),
+                        HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() == 204) {
+                    return;
+                }
+            } catch (Exception ignored) {
+                Thread.sleep(50);
+            }
+        }
+        throw new AssertionError("Daemon server did not become ready");
+    }
+
+    private void shutdown(DaemonMetadata metadata) throws Exception {
+        HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(URI.create("http://" + metadata.host() + ":"
+                                                  + metadata.port() + "/shutdown"))
+                           .header("X-CodeCheck-Token", metadata.token())
+                           .POST(HttpRequest.BodyPublishers.noBody())
+                           .build(),
+                HttpResponse.BodyHandlers.discarding());
+    }
+
+    private FileSelector emptySelector() {
+        return () -> Stream.empty();
+    }
+
+    private Provider<ValidationCheckPipeline> emptyPipelineProvider() {
+        return () -> {
+            ValidationCheckPipeline pipeline = new ValidationCheckPipeline();
+            setField(pipeline, "codeChecker", List.of());
+            return pipeline;
+        };
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set field: " + fieldName, e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the CR-003 implementation specification
- add per-repository daemon metadata under the user cache with stable hashed repo ids
- start/attach using alive metadata, clean stale metadata, allocate random localhost ports, and require local auth tokens
- add token-protected health/check/shutdown control endpoints and inactivity shutdown plumbing

## Tests
- ./mvnw test