### PR TITLE
CR-004: Git change-set policy

### DIFF
--- a/docs/implementation-specs/CR-004-git-change-set-policy.md
+++ b/docs/implementation-specs/CR-004-git-change-set-policy.md
@@ -1,0 +1,54 @@
+# CR-004 Implementation Specification: Git Change-Set Policy
+
+## Scope
+
+This increment introduces an explicit `ChangeSetService` with path metadata and uses it from
+command validation. Existing selector classes remain for compatibility with older daemon/check
+internals until later refactors remove them.
+
+## Change Sets
+
+`ChangeSet` contains `ChangeSetEntry` records with:
+
+- repository-relative path
+- Git status
+- staged flag
+- unstaged flag
+- untracked flag
+- deleted flag
+- origin reason
+
+Deleted entries are represented by the parser but filtered out of command change sets.
+
+## Policies
+
+- Interactive and batch checks use branch-aware selection.
+- Pre-commit uses staged paths from `git diff --cached --name-status --relative`.
+- Assistant mode includes untracked Java files in addition to branch-aware changes.
+- Main/release branches select staged plus unstaged changes.
+- Feature branches select direct diff against the first configured main branch that exists.
+- The first matching configured main branch wins.
+- If no configured main branch exists, the service falls back to staged plus unstaged changes.
+
+## Git Execution
+
+Git commands are executed through `GitCommandRunner`, which waits for process exit, captures stderr,
+and raises `GitCommandException` on non-zero exit codes. Rename output is parsed explicitly and uses
+the new path.
+
+## Command Integration
+
+`CodeCheckCommandService` now validates paths from `ChangeSetService`:
+
+- `runInteractiveCheck`: `currentInteractiveCheckChangeSet`
+- `runBatchCheck`: `currentInteractiveCheckChangeSet`
+- `runPreCommit`: `preCommitChangeSet`
+
+## Tests
+
+- Main branch selection includes staged and unstaged modified files.
+- Deleted files are ignored.
+- Feature branch selection uses direct diff against configured main branch tip.
+- Main branch fallback honors configured branch order.
+- Pre-commit uses staged paths.
+- Assistant mode includes untracked Java files.

--- a/src/main/java/de/zorro909/codecheck/changeset/ChangeSet.java
+++ b/src/main/java/de/zorro909/codecheck/changeset/ChangeSet.java
@@ -1,0 +1,23 @@
+package de.zorro909.codecheck.changeset;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+public record ChangeSet(List<ChangeSetEntry> entries) {
+
+    public ChangeSet {
+        entries = List.copyOf(entries);
+    }
+
+    public static ChangeSet empty() {
+        return new ChangeSet(List.of());
+    }
+
+    public Stream<Path> paths() {
+        return entries.stream()
+                      .filter(entry -> !entry.deleted())
+                      .map(ChangeSetEntry::path)
+                      .distinct();
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/changeset/ChangeSetEntry.java
+++ b/src/main/java/de/zorro909/codecheck/changeset/ChangeSetEntry.java
@@ -1,0 +1,12 @@
+package de.zorro909.codecheck.changeset;
+
+import java.nio.file.Path;
+
+public record ChangeSetEntry(Path path,
+                             GitFileStatus status,
+                             boolean staged,
+                             boolean unstaged,
+                             boolean untracked,
+                             boolean deleted,
+                             String originReason) {
+}

--- a/src/main/java/de/zorro909/codecheck/changeset/ChangeSetService.java
+++ b/src/main/java/de/zorro909/codecheck/changeset/ChangeSetService.java
@@ -1,0 +1,15 @@
+package de.zorro909.codecheck.changeset;
+
+import java.nio.file.Path;
+import java.util.Collection;
+
+public interface ChangeSetService {
+
+    ChangeSet currentAssistantChangeSet();
+
+    ChangeSet currentInteractiveCheckChangeSet();
+
+    ChangeSet preCommitChangeSet();
+
+    ChangeSet explicitFiles(Collection<Path> files);
+}

--- a/src/main/java/de/zorro909/codecheck/changeset/GitChangeSetService.java
+++ b/src/main/java/de/zorro909/codecheck/changeset/GitChangeSetService.java
@@ -108,7 +108,7 @@ public class GitChangeSetService implements ChangeSetService {
     }
 
     private boolean isMainLikeBranch(String currentBranch, CodeCheckConfig.Git gitConfig) {
-        Pattern releasePattern = gitConfig.releaseBranchPattern();
+        Pattern releasePattern = Pattern.compile(gitConfig.releaseBranchPattern());
         return gitConfig.mainBranches().contains(currentBranch)
                || releasePattern.matcher(currentBranch).matches();
     }

--- a/src/main/java/de/zorro909/codecheck/changeset/GitChangeSetService.java
+++ b/src/main/java/de/zorro909/codecheck/changeset/GitChangeSetService.java
@@ -1,7 +1,10 @@
 package de.zorro909.codecheck.changeset;
 
+import de.zorro909.codecheck.RepositoryPathProvider;
 import de.zorro909.codecheck.config.CodeCheckConfig;
 import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 import java.nio.file.Path;
@@ -19,7 +22,10 @@ public class GitChangeSetService implements ChangeSetService {
     private final CodeCheckConfigLoader configLoader;
     private final GitCommandRunner git;
 
-    public GitChangeSetService(Path repositoryDirectory, CodeCheckConfigLoader configLoader) {
+    @Inject
+    public GitChangeSetService(
+            @Named(RepositoryPathProvider.REPOSITORY_DIRECTORY) Path repositoryDirectory,
+            CodeCheckConfigLoader configLoader) {
         this(repositoryDirectory, configLoader, new GitCommandRunner(repositoryDirectory));
     }
 

--- a/src/main/java/de/zorro909/codecheck/changeset/GitChangeSetService.java
+++ b/src/main/java/de/zorro909/codecheck/changeset/GitChangeSetService.java
@@ -1,0 +1,175 @@
+package de.zorro909.codecheck.changeset;
+
+import de.zorro909.codecheck.config.CodeCheckConfig;
+import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import jakarta.inject.Singleton;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+@Singleton
+public class GitChangeSetService implements ChangeSetService {
+
+    private final Path repositoryDirectory;
+    private final CodeCheckConfigLoader configLoader;
+    private final GitCommandRunner git;
+
+    public GitChangeSetService(Path repositoryDirectory, CodeCheckConfigLoader configLoader) {
+        this(repositoryDirectory, configLoader, new GitCommandRunner(repositoryDirectory));
+    }
+
+    GitChangeSetService(Path repositoryDirectory, CodeCheckConfigLoader configLoader,
+                        GitCommandRunner git) {
+        this.repositoryDirectory = repositoryDirectory.toAbsolutePath().normalize();
+        this.configLoader = configLoader;
+        this.git = git;
+    }
+
+    @Override
+    public ChangeSet currentAssistantChangeSet() {
+        List<ChangeSetEntry> entries = new ArrayList<>(branchAwareChangeSet().entries());
+        entries.addAll(untrackedJavaEntries());
+        return deduplicate(entries);
+    }
+
+    @Override
+    public ChangeSet currentInteractiveCheckChangeSet() {
+        return branchAwareChangeSet();
+    }
+
+    @Override
+    public ChangeSet preCommitChangeSet() {
+        return parseNameStatus(git.run("diff", "--cached", "--name-status", "--relative"),
+                               true, false, "pre-commit staged path");
+    }
+
+    @Override
+    public ChangeSet explicitFiles(Collection<Path> files) {
+        return deduplicate(files.stream()
+                                .map(this::repositoryRelative)
+                                .map(path -> new ChangeSetEntry(path, GitFileStatus.UNKNOWN,
+                                                                false, false, false, false,
+                                                                "explicit file"))
+                                .toList());
+    }
+
+    private Path repositoryRelative(Path path) {
+        Path normalized = path.normalize();
+        if (!normalized.isAbsolute()) {
+            return normalized;
+        }
+        return repositoryDirectory.relativize(normalized);
+    }
+
+    private ChangeSet branchAwareChangeSet() {
+        CodeCheckConfig.Git gitConfig = configLoader.load().git();
+        String currentBranch = currentBranch();
+        if (isMainLikeBranch(currentBranch, gitConfig)) {
+            return mainBranchChangeSet();
+        }
+
+        return firstExistingMainBranch(gitConfig.mainBranches())
+                .map(this::featureBranchChangeSet)
+                .orElseGet(this::mainBranchChangeSet);
+    }
+
+    private ChangeSet mainBranchChangeSet() {
+        List<ChangeSetEntry> entries = new ArrayList<>();
+        entries.addAll(parseNameStatus(git.run("diff", "--name-status", "--relative"),
+                                       false, true, "unstaged change").entries());
+        entries.addAll(parseNameStatus(git.run("diff", "--cached", "--name-status", "--relative"),
+                                       true, false, "staged change").entries());
+        return deduplicate(entries);
+    }
+
+    private ChangeSet featureBranchChangeSet(String baseBranch) {
+        return parseNameStatus(git.run("diff", "--name-status", "--relative", baseBranch),
+                               false, true, "direct diff against " + baseBranch);
+    }
+
+    private List<ChangeSetEntry> untrackedJavaEntries() {
+        return git.run("ls-files", "--others", "--exclude-standard")
+                  .stream()
+                  .filter(path -> path.endsWith(".java"))
+                  .map(path -> new ChangeSetEntry(Path.of(path), GitFileStatus.UNTRACKED,
+                                                  false, false, true, false,
+                                                  "untracked java file"))
+                  .toList();
+    }
+
+    private String currentBranch() {
+        List<String> branches = git.run("branch", "--show-current");
+        return branches.isEmpty() ? "" : branches.get(0);
+    }
+
+    private boolean isMainLikeBranch(String currentBranch, CodeCheckConfig.Git gitConfig) {
+        Pattern releasePattern = gitConfig.releaseBranchPattern();
+        return gitConfig.mainBranches().contains(currentBranch)
+               || releasePattern.matcher(currentBranch).matches();
+    }
+
+    private java.util.Optional<String> firstExistingMainBranch(List<String> mainBranches) {
+        return mainBranches.stream()
+                           .filter(branch -> git.succeeds("rev-parse", "--verify", "--quiet",
+                                                          branch))
+                           .findFirst();
+    }
+
+    private ChangeSet parseNameStatus(List<String> lines, boolean staged, boolean unstaged,
+                                      String originReason) {
+        return deduplicate(lines.stream()
+                                .map(line -> parseNameStatusLine(line, staged, unstaged,
+                                                                 originReason))
+                                .filter(entry -> !entry.deleted())
+                                .toList());
+    }
+
+    private ChangeSetEntry parseNameStatusLine(String line, boolean staged, boolean unstaged,
+                                               String originReason) {
+        String[] parts = line.split("\t");
+        if (parts.length < 2) {
+            throw new GitCommandException("Unexpected git name-status output: " + line);
+        }
+        GitFileStatus status = status(parts[0]);
+        Path path = Path.of(parts.length >= 3 && (status == GitFileStatus.RENAMED
+                                                  || status == GitFileStatus.COPIED)
+                            ? parts[2] : parts[1]);
+        boolean deleted = status == GitFileStatus.DELETED;
+        return new ChangeSetEntry(path, status, staged, unstaged, false, deleted, originReason);
+    }
+
+    private GitFileStatus status(String statusText) {
+        return switch (statusText.charAt(0)) {
+            case 'A' -> GitFileStatus.ADDED;
+            case 'C' -> GitFileStatus.COPIED;
+            case 'D' -> GitFileStatus.DELETED;
+            case 'M' -> GitFileStatus.MODIFIED;
+            case 'R' -> GitFileStatus.RENAMED;
+            case 'T' -> GitFileStatus.TYPE_CHANGED;
+            case 'U' -> GitFileStatus.UNMERGED;
+            default -> GitFileStatus.UNKNOWN;
+        };
+    }
+
+    private ChangeSet deduplicate(List<ChangeSetEntry> entries) {
+        Map<Path, ChangeSetEntry> merged = new LinkedHashMap<>();
+        for (ChangeSetEntry entry : entries) {
+            merged.merge(entry.path(), entry, this::merge);
+        }
+        return new ChangeSet(merged.values().stream().filter(entry -> !entry.deleted()).toList());
+    }
+
+    private ChangeSetEntry merge(ChangeSetEntry left, ChangeSetEntry right) {
+        return new ChangeSetEntry(left.path(), right.status(),
+                                  left.staged() || right.staged(),
+                                  left.unstaged() || right.unstaged(),
+                                  left.untracked() || right.untracked(),
+                                  left.deleted() && right.deleted(),
+                                  left.originReason() + ", " + right.originReason());
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/changeset/GitCommandException.java
+++ b/src/main/java/de/zorro909/codecheck/changeset/GitCommandException.java
@@ -1,0 +1,12 @@
+package de.zorro909.codecheck.changeset;
+
+public class GitCommandException extends RuntimeException {
+
+    public GitCommandException(String message) {
+        super(message);
+    }
+
+    public GitCommandException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/changeset/GitCommandRunner.java
+++ b/src/main/java/de/zorro909/codecheck/changeset/GitCommandRunner.java
@@ -1,0 +1,64 @@
+package de.zorro909.codecheck.changeset;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+
+public class GitCommandRunner {
+
+    private final Path repositoryDirectory;
+
+    public GitCommandRunner(Path repositoryDirectory) {
+        this.repositoryDirectory = repositoryDirectory.toAbsolutePath().normalize();
+    }
+
+    public List<String> run(String... args) {
+        ProcessBuilder builder = new ProcessBuilder(command(args));
+        builder.directory(repositoryDirectory.toFile());
+        try {
+            Process process = builder.start();
+            String stdout = new String(process.getInputStream().readAllBytes(),
+                                       StandardCharsets.UTF_8);
+            String stderr = new String(process.getErrorStream().readAllBytes(),
+                                       StandardCharsets.UTF_8);
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new GitCommandException("git " + String.join(" ", args)
+                                              + " failed with exit code " + exitCode + ": "
+                                              + stderr.strip());
+            }
+            return stdout.lines().filter(line -> !line.isBlank()).toList();
+        } catch (IOException e) {
+            throw new GitCommandException("Failed to execute git " + String.join(" ", args), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new GitCommandException("Interrupted while executing git "
+                                          + String.join(" ", args), e);
+        }
+    }
+
+    public boolean succeeds(String... args) {
+        ProcessBuilder builder = new ProcessBuilder(command(args));
+        builder.directory(repositoryDirectory.toFile());
+        try {
+            Process process = builder.start();
+            process.getInputStream().readAllBytes();
+            process.getErrorStream().readAllBytes();
+            return process.waitFor() == 0;
+        } catch (IOException e) {
+            throw new GitCommandException("Failed to execute git " + String.join(" ", args), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new GitCommandException("Interrupted while executing git "
+                                          + String.join(" ", args), e);
+        }
+    }
+
+    private List<String> command(String... args) {
+        List<String> command = new java.util.ArrayList<>();
+        command.add("git");
+        command.addAll(List.of(args));
+        return command;
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/changeset/GitFileStatus.java
+++ b/src/main/java/de/zorro909/codecheck/changeset/GitFileStatus.java
@@ -1,0 +1,13 @@
+package de.zorro909.codecheck.changeset;
+
+public enum GitFileStatus {
+    ADDED,
+    COPIED,
+    DELETED,
+    MODIFIED,
+    RENAMED,
+    TYPE_CHANGED,
+    UNMERGED,
+    UNKNOWN,
+    UNTRACKED
+}

--- a/src/main/java/de/zorro909/codecheck/command/CodeCheckCommandService.java
+++ b/src/main/java/de/zorro909/codecheck/command/CodeCheckCommandService.java
@@ -1,6 +1,9 @@
 package de.zorro909.codecheck.command;
 
 import de.zorro909.codecheck.ValidationCheckPipeline;
+import de.zorro909.codecheck.changeset.ChangeSet;
+import de.zorro909.codecheck.changeset.ChangeSetService;
+import de.zorro909.codecheck.changeset.GitCommandException;
 import de.zorro909.codecheck.checks.ValidationError;
 import de.zorro909.codecheck.config.CodeCheckConfigLoader;
 import de.zorro909.codecheck.config.ConfigException;
@@ -15,6 +18,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 @Singleton
@@ -22,7 +26,7 @@ public class CodeCheckCommandService {
 
     private final AssistantDaemonController assistantDaemonController;
     private final ValidationCheckPipeline validationCheckPipeline;
-    private final FileSelector fileSelector;
+    private final ChangeSetService changeSetService;
     private final CodeCheckConfigLoader configLoader;
     private final PrintStream out;
     private final PrintStream err;
@@ -30,16 +34,16 @@ public class CodeCheckCommandService {
     @Inject
     public CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
                                    ValidationCheckPipeline validationCheckPipeline,
-                                   FileSelector fileSelector,
+                                   ChangeSetService changeSetService,
                                    CodeCheckConfigLoader configLoader) {
-        this(assistantDaemonController, validationCheckPipeline, fileSelector, configLoader,
+        this(assistantDaemonController, validationCheckPipeline, changeSetService, configLoader,
              System.out, System.err);
     }
 
     public CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
                                    ValidationCheckPipeline validationCheckPipeline,
                                    FileSelector fileSelector) {
-        this(assistantDaemonController, validationCheckPipeline, fileSelector,
+        this(assistantDaemonController, validationCheckPipeline, fromFileSelector(fileSelector),
              CodeCheckConfigLoader.defaultsOnly(), System.out, System.err);
     }
 
@@ -48,7 +52,7 @@ public class CodeCheckCommandService {
                             FileSelector fileSelector,
                             PrintStream out,
                             PrintStream err) {
-        this(assistantDaemonController, validationCheckPipeline, fileSelector,
+        this(assistantDaemonController, validationCheckPipeline, fromFileSelector(fileSelector),
              CodeCheckConfigLoader.defaultsOnly(), out, err);
     }
 
@@ -58,9 +62,19 @@ public class CodeCheckCommandService {
                             CodeCheckConfigLoader configLoader,
                             PrintStream out,
                             PrintStream err) {
+        this(assistantDaemonController, validationCheckPipeline, fromFileSelector(fileSelector),
+             configLoader, out, err);
+    }
+
+    CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
+                            ValidationCheckPipeline validationCheckPipeline,
+                            ChangeSetService changeSetService,
+                            CodeCheckConfigLoader configLoader,
+                            PrintStream out,
+                            PrintStream err) {
         this.assistantDaemonController = assistantDaemonController;
         this.validationCheckPipeline = validationCheckPipeline;
-        this.fileSelector = fileSelector;
+        this.changeSetService = changeSetService;
         this.configLoader = configLoader;
         this.out = out;
         this.err = err;
@@ -84,7 +98,8 @@ public class CodeCheckCommandService {
             return CommandOutcome.failure();
         }
         try {
-            Map<Path, List<ValidationError>> errorsMap = collectErrors();
+            Map<Path, List<ValidationError>> errorsMap = collectErrors(
+                    changeSetService.currentInteractiveCheckChangeSet());
             printOverview(errorsMap, _ -> true);
 
             if (errorsMap.isEmpty()) {
@@ -101,15 +116,19 @@ public class CodeCheckCommandService {
         } catch (IOException e) {
             err.println("Failed to run interactive check: " + e.getMessage());
             return CommandOutcome.failure();
+        } catch (GitCommandException e) {
+            err.println("Failed to select files for interactive check: " + e.getMessage());
+            return CommandOutcome.failure();
         }
     }
 
     public CommandOutcome runBatchCheck() {
-        return runNonInteractive("batch check", _ -> true);
+        return runNonInteractive("batch check", changeSetService::currentInteractiveCheckChangeSet,
+                                 _ -> true);
     }
 
     public CommandOutcome runPreCommit() {
-        return runNonInteractive("pre-commit check",
+        return runNonInteractive("pre-commit check", changeSetService::preCommitChangeSet,
                                  error -> error.severity() != ValidationError.Severity.LOW);
     }
 
@@ -135,22 +154,27 @@ public class CodeCheckCommandService {
     }
 
     private CommandOutcome runNonInteractive(String label,
+                                             Supplier<ChangeSet> changeSetSupplier,
                                              Predicate<ValidationError> diagnosticFilter) {
         if (!loadConfig()) {
             return CommandOutcome.failure();
         }
         try {
-            Map<Path, List<ValidationError>> errorsMap = collectErrors();
+            Map<Path, List<ValidationError>> errorsMap = collectErrors(changeSetSupplier.get());
             printOverview(errorsMap, diagnosticFilter);
             return hasHighSeverity(errorsMap) ? CommandOutcome.failure() : CommandOutcome.success();
         } catch (IOException e) {
             err.println("Failed to run " + label + ": " + e.getMessage());
             return CommandOutcome.failure();
+        } catch (GitCommandException e) {
+            err.println("Failed to select files for " + label + ": " + e.getMessage());
+            return CommandOutcome.failure();
         }
     }
 
-    private Map<Path, List<ValidationError>> collectErrors() throws IOException {
-        try (Stream<Path> changedFiles = fileSelector.selectFiles()) {
+    private Map<Path, List<ValidationError>> collectErrors(ChangeSet changeSet)
+            throws IOException {
+        try (Stream<Path> changedFiles = changeSet.paths()) {
             return validationCheckPipeline.checkForErrors(changedFiles);
         }
     }
@@ -199,5 +223,42 @@ public class CodeCheckCommandService {
             err.println(e.getMessage());
             return false;
         }
+    }
+
+    private static ChangeSetService fromFileSelector(FileSelector fileSelector) {
+        return new ChangeSetService() {
+            @Override
+            public ChangeSet currentAssistantChangeSet() {
+                return fromSelector();
+            }
+
+            @Override
+            public ChangeSet currentInteractiveCheckChangeSet() {
+                return fromSelector();
+            }
+
+            @Override
+            public ChangeSet preCommitChangeSet() {
+                return fromSelector();
+            }
+
+            @Override
+            public ChangeSet explicitFiles(java.util.Collection<Path> files) {
+                return new ChangeSet(files.stream()
+                                          .map(path -> new de.zorro909.codecheck.changeset.ChangeSetEntry(
+                                                  path,
+                                                  de.zorro909.codecheck.changeset.GitFileStatus.UNKNOWN,
+                                                  false, false, false, false, "explicit file"))
+                                          .toList());
+            }
+
+            private ChangeSet fromSelector() {
+                try (Stream<Path> selected = fileSelector.selectFiles()) {
+                    return explicitFiles(selected.toList());
+                } catch (IOException e) {
+                    throw new IllegalStateException("Failed to select files", e);
+                }
+            }
+        };
     }
 }

--- a/src/test/java/de/zorro909/codecheck/changeset/GitChangeSetServiceBeanTest.java
+++ b/src/test/java/de/zorro909/codecheck/changeset/GitChangeSetServiceBeanTest.java
@@ -1,0 +1,18 @@
+package de.zorro909.codecheck.changeset;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitChangeSetServiceBeanTest {
+
+    @Test
+    void changeSetServiceBeanResolvesGitImplementation() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ChangeSetService service = context.getBean(ChangeSetService.class);
+
+            assertThat(service).isInstanceOf(GitChangeSetService.class);
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/changeset/GitChangeSetServiceTest.java
+++ b/src/test/java/de/zorro909/codecheck/changeset/GitChangeSetServiceTest.java
@@ -1,0 +1,165 @@
+package de.zorro909.codecheck.changeset;
+
+import de.zorro909.codecheck.config.CodeCheckConfig;
+import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import de.zorro909.codecheck.config.ConfigOverrides;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitChangeSetServiceTest {
+
+    @Test
+    void mainBranchSelectionIncludesStagedAndUnstagedChangesAndIgnoresDeleted(
+            @TempDir Path repo) throws Exception {
+        initRepo(repo, "develop");
+        write(repo, "Modified.java", "class Modified {}\n");
+        write(repo, "Staged.java", "class Staged {}\n");
+        write(repo, "Deleted.java", "class Deleted {}\n");
+        git(repo, "add", ".");
+        git(repo, "commit", "-m", "base");
+        write(repo, "Modified.java", "class Modified { int value; }\n");
+        write(repo, "Staged.java", "class Staged { int value; }\n");
+        git(repo, "add", "Staged.java");
+        Files.delete(repo.resolve("Deleted.java"));
+
+        ChangeSet changeSet = service(repo, List.of("develop", "main")).currentInteractiveCheckChangeSet();
+
+        assertThat(paths(changeSet)).containsExactlyInAnyOrder("Modified.java", "Staged.java");
+        assertThat(changeSet.entries()).anySatisfy(entry -> {
+            assertThat(entry.path()).isEqualTo(Path.of("Modified.java"));
+            assertThat(entry.unstaged()).isTrue();
+        });
+        assertThat(changeSet.entries()).anySatisfy(entry -> {
+            assertThat(entry.path()).isEqualTo(Path.of("Staged.java"));
+            assertThat(entry.staged()).isTrue();
+        });
+    }
+
+    @Test
+    void featureBranchUsesDirectDiffAgainstFirstExistingMainBranch(@TempDir Path repo)
+            throws Exception {
+        initRepo(repo, "develop");
+        write(repo, "Feature.java", "class Feature {}\n");
+        git(repo, "add", ".");
+        git(repo, "commit", "-m", "base");
+        git(repo, "checkout", "-b", "feature/demo");
+        write(repo, "Feature.java", "class Feature { int value; }\n");
+
+        ChangeSet changeSet = service(repo, List.of("develop", "main")).currentInteractiveCheckChangeSet();
+
+        assertThat(paths(changeSet)).containsExactly("Feature.java");
+        assertThat(changeSet.entries().get(0).originReason()).contains("direct diff against develop");
+    }
+
+    @Test
+    void featureBranchFallsBackToNextConfiguredMainBranch(@TempDir Path repo) throws Exception {
+        initRepo(repo, "main");
+        write(repo, "Fallback.java", "class Fallback {}\n");
+        git(repo, "add", ".");
+        git(repo, "commit", "-m", "base");
+        git(repo, "checkout", "-b", "feature/fallback");
+        write(repo, "Fallback.java", "class Fallback { int value; }\n");
+
+        ChangeSet changeSet = service(repo, List.of("develop", "main")).currentInteractiveCheckChangeSet();
+
+        assertThat(paths(changeSet)).containsExactly("Fallback.java");
+        assertThat(changeSet.entries().get(0).originReason()).contains("direct diff against main");
+    }
+
+    @Test
+    void preCommitUsesStagedPaths(@TempDir Path repo) throws Exception {
+        initRepo(repo, "develop");
+        write(repo, "PreCommit.java", "class PreCommit {}\n");
+        git(repo, "add", ".");
+        git(repo, "commit", "-m", "base");
+        write(repo, "PreCommit.java", "class PreCommit { int staged; }\n");
+        git(repo, "add", "PreCommit.java");
+        write(repo, "PreCommit.java", "class PreCommit { int staged; int workingTree; }\n");
+
+        ChangeSet changeSet = service(repo, List.of("develop")).preCommitChangeSet();
+
+        assertThat(paths(changeSet)).containsExactly("PreCommit.java");
+        assertThat(changeSet.entries().get(0).staged()).isTrue();
+    }
+
+    @Test
+    void assistantIncludesUntrackedJavaFiles(@TempDir Path repo) throws Exception {
+        initRepo(repo, "develop");
+        write(repo, "Tracked.java", "class Tracked {}\n");
+        git(repo, "add", ".");
+        git(repo, "commit", "-m", "base");
+        write(repo, "NewAssistantFile.java", "class NewAssistantFile {}\n");
+        write(repo, "notes.txt", "notes\n");
+
+        ChangeSet changeSet = service(repo, List.of("develop")).currentAssistantChangeSet();
+
+        assertThat(paths(changeSet)).contains("NewAssistantFile.java");
+        assertThat(paths(changeSet)).doesNotContain("notes.txt");
+        assertThat(changeSet.entries()).anySatisfy(entry -> {
+            assertThat(entry.path()).isEqualTo(Path.of("NewAssistantFile.java"));
+            assertThat(entry.untracked()).isTrue();
+        });
+    }
+
+    private GitChangeSetService service(Path repo, List<String> mainBranches) {
+        return new GitChangeSetService(repo, loader(mainBranches));
+    }
+
+    private CodeCheckConfigLoader loader(List<String> mainBranches) {
+        CodeCheckConfig config = CodeCheckConfig.defaults()
+                                               .withGit(new CodeCheckConfig.Git(
+                                                       mainBranches,
+                                                       Pattern.compile("release/.*"),
+                                                       true));
+        return new CodeCheckConfigLoader() {
+            @Override
+            public CodeCheckConfig load() {
+                return config;
+            }
+
+            @Override
+            public CodeCheckConfig load(ConfigOverrides overrides) {
+                return overrides.apply(config);
+            }
+        };
+    }
+
+    private List<String> paths(ChangeSet changeSet) {
+        return changeSet.paths().map(Path::toString).toList();
+    }
+
+    private void initRepo(Path repo, String branch) throws Exception {
+        git(repo, "init");
+        git(repo, "config", "user.email", "test@example.invalid");
+        git(repo, "config", "user.name", "Test User");
+        git(repo, "checkout", "-b", branch);
+    }
+
+    private void write(Path repo, String relativePath, String content) throws Exception {
+        Path file = repo.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content, StandardCharsets.UTF_8);
+    }
+
+    private void git(Path repo, String... args) throws Exception {
+        List<String> command = new java.util.ArrayList<>();
+        command.add("git");
+        command.addAll(List.of(args));
+        Process process = new ProcessBuilder(command).directory(repo.toFile()).start();
+        String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+        String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new AssertionError("git " + String.join(" ", args) + " failed: "
+                                     + stdout + stderr);
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/changeset/GitChangeSetServiceTest.java
+++ b/src/test/java/de/zorro909/codecheck/changeset/GitChangeSetServiceTest.java
@@ -10,7 +10,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -117,7 +116,7 @@ class GitChangeSetServiceTest {
         CodeCheckConfig config = CodeCheckConfig.defaults()
                                                .withGit(new CodeCheckConfig.Git(
                                                        mainBranches,
-                                                       Pattern.compile("release/.*"),
+                                                       "release/.*",
                                                        true));
         return new CodeCheckConfigLoader() {
             @Override


### PR DESCRIPTION
## Summary
- add the CR-004 implementation specification
- introduce structured ChangeSet metadata and a Git-backed ChangeSetService
- implement branch-aware main/release/feature selection, staged pre-commit selection, deleted-file filtering, rename parsing, and assistant untracked Java inclusion
- route interactive, batch, and pre-commit command validation through the change-set service

## Tests
- ./mvnw test