### PR TITLE
CR-005: Validation engine, rules, and fixers

### DIFF
--- a/docs/implementation-specs/CR-005-validation-engine-rules-and-fixers.md
+++ b/docs/implementation-specs/CR-005-validation-engine-rules-and-fixers.md
@@ -1,0 +1,52 @@
+# CR-005 Implementation Specification: Validation Engine, Rules, and Fixers
+
+## Scope
+
+This increment introduces a structured validation engine and rule/fixer contracts while preserving
+the existing `CodeCheck`, `FixAction`, and `PostAction` implementations through adapters.
+
+## Core Types
+
+- `Rule`, `RuleId`, `RuleMetadata`, `FileInterest`, `ValidationContext`
+- `Diagnostic`, `DiagnosticKind`, `SourcePosition`, `ValidationMode`
+- `ValidationEngine`, `ValidationResult`, `FileValidationResult`
+- `Fixer`, `FixerId`, `FixerMetadata`, `FixInteraction`, `FixPlan`, `FixResult`
+- `RuleRegistry`, `WatchPlan`
+
+## Migration Strategy
+
+- Existing `CodeCheck` implementations expose default rule metadata and file interests.
+- Existing `FixAction` implementations expose default fixer metadata.
+- `DefaultRuleRegistry` adapts injected `CodeCheck` instances into rules and `FixAction`
+  instances into fixers.
+- `DefaultValidationEngine` depends only on `RuleRegistry`, `ChangeSet`, and validation types.
+  It does not print, call `System.exit`, launch editors, or depend on Picocli.
+- `ValidationCheckPipeline` delegates validation to the engine for checks and keeps its
+  compatibility methods for existing command code and tests.
+
+## Fix Semantics
+
+- Interactive fixers are filtered out for `BATCH` and `PRE_COMMIT` modes.
+- User-triggered fixing is represented by `FixApplicationService`.
+- A fix result reports modified/created files.
+- Affected files are fully rechecked after the fix.
+- Post actions, including Git restaging, run only when the affected-file recheck passes.
+
+## File Interests
+
+`NoMagicValuesCheck` declares Java main-source validation interest:
+
+```text
+src/main/java/**/*.java
+```
+
+This interest is visible through the rule registry watch plan.
+
+## Tests
+
+- Existing validation checks are available as structured rules.
+- `NoMagicValuesCheck` exposes Java main-source file interest.
+- The validation engine returns structured diagnostics without printing.
+- Manual editor fixing is represented as an interactive fixer.
+- Interactive fixers are unavailable in batch mode.
+- A user-triggered fix that affects two files restages both files after successful recheck.

--- a/src/main/java/de/zorro909/codecheck/ValidationCheckPipeline.java
+++ b/src/main/java/de/zorro909/codecheck/ValidationCheckPipeline.java
@@ -2,10 +2,18 @@ package de.zorro909.codecheck;
 
 import de.zorro909.codecheck.actions.FixAction;
 import de.zorro909.codecheck.actions.PostAction;
+import de.zorro909.codecheck.changeset.ChangeSet;
+import de.zorro909.codecheck.changeset.ChangeSetEntry;
+import de.zorro909.codecheck.changeset.GitFileStatus;
 import de.zorro909.codecheck.checks.CodeCheck;
 import de.zorro909.codecheck.checks.ValidationError;
 import de.zorro909.codecheck.editor.EditorExecutor;
 import de.zorro909.codecheck.selector.FileSelector;
+import de.zorro909.codecheck.validation.Diagnostic;
+import de.zorro909.codecheck.validation.DefaultValidationEngine;
+import de.zorro909.codecheck.validation.RuleRegistry;
+import de.zorro909.codecheck.validation.ValidationEngine;
+import de.zorro909.codecheck.validation.ValidationMode;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -34,6 +42,9 @@ public class ValidationCheckPipeline {
 
     @Inject
     List<PostAction> postActions;
+
+    @Inject
+    ValidationEngine validationEngine;
 
     /**
      * Execute all PostActions on a Set of Paths
@@ -90,15 +101,32 @@ public class ValidationCheckPipeline {
     }
 
     public Map<Path, List<ValidationError>> checkForErrors(Stream<Path> changedFiles) {
-        return changedFiles.flatMap(this::checkFile)
-                           .collect(Collectors.groupingBy(ValidationError::filePath));
+        ChangeSet changeSet = new ChangeSet(changedFiles.map(path -> new ChangeSetEntry(
+                                                     path, GitFileStatus.UNKNOWN, false, false,
+                                                     false, false, "validation pipeline"))
+                                             .toList());
+        return validationEngine().validate(changeSet, ValidationMode.INTERACTIVE)
+                                 .diagnostics()
+                                 .stream()
+                                 .map(Diagnostic::toValidationError)
+                                 .collect(Collectors.groupingBy(ValidationError::filePath));
     }
 
     public Stream<ValidationError> checkFile(Path file) {
-        codeChecker.forEach(cc -> cc.resetCache(file));
-        return codeChecker.stream()
-                          .filter(checker -> checker.isResponsible(file))
-                          .flatMap(checker -> checker.check(file).stream());
+        return validationEngine().validateFile(file, ValidationMode.INTERACTIVE)
+                                 .diagnostics()
+                                 .stream()
+                                 .map(Diagnostic::toValidationError);
+    }
+
+    private ValidationEngine validationEngine() {
+        if (validationEngine != null) {
+            return validationEngine;
+        }
+        RuleRegistry registry = new de.zorro909.codecheck.validation.DefaultRuleRegistry(
+                codeChecker == null ? List.of() : codeChecker,
+                fixActions == null ? List.of() : fixActions);
+        return new DefaultValidationEngine(registry);
     }
 
 }

--- a/src/main/java/de/zorro909/codecheck/actions/FixAction.java
+++ b/src/main/java/de/zorro909/codecheck/actions/FixAction.java
@@ -1,11 +1,29 @@
 package de.zorro909.codecheck.actions;
 
 import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.validation.FixInteraction;
+import de.zorro909.codecheck.validation.FixerId;
+import de.zorro909.codecheck.validation.FixerMetadata;
+
+import java.nio.file.Path;
+import java.util.Set;
 
 public interface FixAction {
+
+    default FixerId fixerId() {
+        return new FixerId(getClass().getSimpleName());
+    }
+
+    default FixerMetadata fixerMetadata() {
+        return new FixerMetadata(getClass().getSimpleName(), FixInteraction.NONE);
+    }
 
     boolean canFixError(ValidationError validationError);
 
     boolean fixError(ValidationError validationError);
+
+    default Set<Path> affectedFiles(ValidationError validationError) {
+        return Set.of(validationError.filePath());
+    }
 
 }

--- a/src/main/java/de/zorro909/codecheck/actions/fix/ManualEditorFixAction.java
+++ b/src/main/java/de/zorro909/codecheck/actions/fix/ManualEditorFixAction.java
@@ -5,6 +5,8 @@ import de.zorro909.codecheck.RequiresCliOption;
 import de.zorro909.codecheck.actions.FixAction;
 import de.zorro909.codecheck.checks.ValidationError;
 import de.zorro909.codecheck.editor.EditorExecutor;
+import de.zorro909.codecheck.validation.FixInteraction;
+import de.zorro909.codecheck.validation.FixerMetadata;
 import io.micronaut.core.annotation.Order;
 import jakarta.inject.Singleton;
 
@@ -19,6 +21,11 @@ public class ManualEditorFixAction implements FixAction {
 
     public ManualEditorFixAction(EditorExecutor editorExecutor) {
         this.editorExecutor = editorExecutor;
+    }
+
+    @Override
+    public FixerMetadata fixerMetadata() {
+        return new FixerMetadata("Manual IDE editor", FixInteraction.INTERACTIVE);
     }
 
     @Override

--- a/src/main/java/de/zorro909/codecheck/checks/CodeCheck.java
+++ b/src/main/java/de/zorro909/codecheck/checks/CodeCheck.java
@@ -1,5 +1,9 @@
 package de.zorro909.codecheck.checks;
 
+import de.zorro909.codecheck.validation.FileInterest;
+import de.zorro909.codecheck.validation.RuleId;
+import de.zorro909.codecheck.validation.RuleMetadata;
+
 import java.nio.file.Path;
 import java.util.List;
 
@@ -7,6 +11,22 @@ import java.util.List;
  * The CodeCheck interface provides methods to check code files for certain conditions and validate them.
  */
 public interface CodeCheck {
+
+    default RuleId ruleId() {
+        return new RuleId(getClass().getSimpleName());
+    }
+
+    default RuleMetadata ruleMetadata() {
+        return new RuleMetadata(getClass().getSimpleName(), "Legacy validation check");
+    }
+
+    default FileInterest validatedFiles() {
+        return FileInterest.any();
+    }
+
+    default FileInterest contextFiles() {
+        return FileInterest.none();
+    }
 
     boolean isResponsible(Path file);
 

--- a/src/main/java/de/zorro909/codecheck/checks/java/code/NoMagicValuesCheck.java
+++ b/src/main/java/de/zorro909/codecheck/checks/java/code/NoMagicValuesCheck.java
@@ -8,6 +8,9 @@ import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import de.zorro909.codecheck.FileLoader;
 import de.zorro909.codecheck.checks.ValidationError;
 import de.zorro909.codecheck.checks.java.JavaChecker;
+import de.zorro909.codecheck.validation.FileInterest;
+import de.zorro909.codecheck.validation.RuleId;
+import de.zorro909.codecheck.validation.RuleMetadata;
 import jakarta.inject.Singleton;
 
 import java.io.File;
@@ -28,6 +31,22 @@ public class NoMagicValuesCheck extends JavaChecker {
 
     public NoMagicValuesCheck(FileLoader fileLoader) {
         super(fileLoader);
+    }
+
+    @Override
+    public RuleId ruleId() {
+        return new RuleId("java.no-magic-values");
+    }
+
+    @Override
+    public RuleMetadata ruleMetadata() {
+        return new RuleMetadata("No magic values",
+                                "Rejects literal method and constructor arguments in main Java sources.");
+    }
+
+    @Override
+    public FileInterest validatedFiles() {
+        return FileInterest.javaMainSources();
     }
 
     @Override

--- a/src/main/java/de/zorro909/codecheck/command/CodeCheckCommandService.java
+++ b/src/main/java/de/zorro909/codecheck/command/CodeCheckCommandService.java
@@ -9,6 +9,9 @@ import de.zorro909.codecheck.config.CodeCheckConfigLoader;
 import de.zorro909.codecheck.config.ConfigException;
 import de.zorro909.codecheck.config.ConfigOverrides;
 import de.zorro909.codecheck.selector.FileSelector;
+import de.zorro909.codecheck.validation.Diagnostic;
+import de.zorro909.codecheck.validation.ValidationEngine;
+import de.zorro909.codecheck.validation.ValidationMode;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -26,6 +29,7 @@ public class CodeCheckCommandService {
 
     private final AssistantDaemonController assistantDaemonController;
     private final ValidationCheckPipeline validationCheckPipeline;
+    private final ValidationEngine validationEngine;
     private final ChangeSetService changeSetService;
     private final CodeCheckConfigLoader configLoader;
     private final PrintStream out;
@@ -34,10 +38,11 @@ public class CodeCheckCommandService {
     @Inject
     public CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
                                    ValidationCheckPipeline validationCheckPipeline,
+                                   ValidationEngine validationEngine,
                                    ChangeSetService changeSetService,
                                    CodeCheckConfigLoader configLoader) {
-        this(assistantDaemonController, validationCheckPipeline, changeSetService, configLoader,
-             System.out, System.err);
+        this(assistantDaemonController, validationCheckPipeline, validationEngine,
+             changeSetService, configLoader, System.out, System.err);
     }
 
     public CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
@@ -72,8 +77,20 @@ public class CodeCheckCommandService {
                             CodeCheckConfigLoader configLoader,
                             PrintStream out,
                             PrintStream err) {
+        this(assistantDaemonController, validationCheckPipeline, null, changeSetService,
+             configLoader, out, err);
+    }
+
+    CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
+                            ValidationCheckPipeline validationCheckPipeline,
+                            ValidationEngine validationEngine,
+                            ChangeSetService changeSetService,
+                            CodeCheckConfigLoader configLoader,
+                            PrintStream out,
+                            PrintStream err) {
         this.assistantDaemonController = assistantDaemonController;
         this.validationCheckPipeline = validationCheckPipeline;
+        this.validationEngine = validationEngine;
         this.changeSetService = changeSetService;
         this.configLoader = configLoader;
         this.out = out;
@@ -99,7 +116,8 @@ public class CodeCheckCommandService {
         }
         try {
             Map<Path, List<ValidationError>> errorsMap = collectErrors(
-                    changeSetService.currentInteractiveCheckChangeSet());
+                    changeSetService.currentInteractiveCheckChangeSet(),
+                    ValidationMode.INTERACTIVE);
             printOverview(errorsMap, _ -> true);
 
             if (errorsMap.isEmpty()) {
@@ -160,7 +178,8 @@ public class CodeCheckCommandService {
             return CommandOutcome.failure();
         }
         try {
-            Map<Path, List<ValidationError>> errorsMap = collectErrors(changeSetSupplier.get());
+            Map<Path, List<ValidationError>> errorsMap = collectErrors(changeSetSupplier.get(),
+                                                                       modeFor(label));
             printOverview(errorsMap, diagnosticFilter);
             return hasHighSeverity(errorsMap) ? CommandOutcome.failure() : CommandOutcome.success();
         } catch (IOException e) {
@@ -172,8 +191,17 @@ public class CodeCheckCommandService {
         }
     }
 
-    private Map<Path, List<ValidationError>> collectErrors(ChangeSet changeSet)
+    private Map<Path, List<ValidationError>> collectErrors(ChangeSet changeSet,
+                                                           ValidationMode mode)
             throws IOException {
+        if (validationEngine != null) {
+            return validationEngine.validate(changeSet, mode)
+                                   .diagnostics()
+                                   .stream()
+                                   .map(Diagnostic::toValidationError)
+                                   .collect(java.util.stream.Collectors.groupingBy(
+                                           ValidationError::filePath));
+        }
         try (Stream<Path> changedFiles = changeSet.paths()) {
             return validationCheckPipeline.checkForErrors(changedFiles);
         }
@@ -223,6 +251,14 @@ public class CodeCheckCommandService {
             err.println(e.getMessage());
             return false;
         }
+    }
+
+    private ValidationMode modeFor(String label) {
+        return switch (label) {
+            case "batch check" -> ValidationMode.BATCH;
+            case "pre-commit check" -> ValidationMode.PRE_COMMIT;
+            default -> ValidationMode.INTERACTIVE;
+        };
     }
 
     private static ChangeSetService fromFileSelector(FileSelector fileSelector) {

--- a/src/main/java/de/zorro909/codecheck/command/CodeCheckCommandService.java
+++ b/src/main/java/de/zorro909/codecheck/command/CodeCheckCommandService.java
@@ -141,12 +141,14 @@ public class CodeCheckCommandService {
     }
 
     public CommandOutcome runBatchCheck() {
-        return runNonInteractive("batch check", changeSetService::currentInteractiveCheckChangeSet,
+        return runNonInteractive("batch check", ValidationMode.BATCH,
+                                 changeSetService::currentInteractiveCheckChangeSet,
                                  _ -> true);
     }
 
     public CommandOutcome runPreCommit() {
-        return runNonInteractive("pre-commit check", changeSetService::preCommitChangeSet,
+        return runNonInteractive("pre-commit check", ValidationMode.PRE_COMMIT,
+                                 changeSetService::preCommitChangeSet,
                                  error -> error.severity() != ValidationError.Severity.LOW);
     }
 
@@ -172,6 +174,7 @@ public class CodeCheckCommandService {
     }
 
     private CommandOutcome runNonInteractive(String label,
+                                             ValidationMode mode,
                                              Supplier<ChangeSet> changeSetSupplier,
                                              Predicate<ValidationError> diagnosticFilter) {
         if (!loadConfig()) {
@@ -179,7 +182,7 @@ public class CodeCheckCommandService {
         }
         try {
             Map<Path, List<ValidationError>> errorsMap = collectErrors(changeSetSupplier.get(),
-                                                                       modeFor(label));
+                                                                       mode);
             printOverview(errorsMap, diagnosticFilter);
             return hasHighSeverity(errorsMap) ? CommandOutcome.failure() : CommandOutcome.success();
         } catch (IOException e) {
@@ -251,14 +254,6 @@ public class CodeCheckCommandService {
             err.println(e.getMessage());
             return false;
         }
-    }
-
-    private ValidationMode modeFor(String label) {
-        return switch (label) {
-            case "batch check" -> ValidationMode.BATCH;
-            case "pre-commit check" -> ValidationMode.PRE_COMMIT;
-            default -> ValidationMode.INTERACTIVE;
-        };
     }
 
     private static ChangeSetService fromFileSelector(FileSelector fileSelector) {

--- a/src/main/java/de/zorro909/codecheck/validation/CodeCheckRuleAdapter.java
+++ b/src/main/java/de/zorro909/codecheck/validation/CodeCheckRuleAdapter.java
@@ -1,0 +1,47 @@
+package de.zorro909.codecheck.validation;
+
+import de.zorro909.codecheck.checks.CodeCheck;
+
+import java.nio.file.Path;
+import java.util.List;
+
+final class CodeCheckRuleAdapter implements Rule {
+
+    private final CodeCheck codeCheck;
+
+    CodeCheckRuleAdapter(CodeCheck codeCheck) {
+        this.codeCheck = codeCheck;
+    }
+
+    @Override
+    public RuleId id() {
+        return codeCheck.ruleId();
+    }
+
+    @Override
+    public RuleMetadata metadata() {
+        return codeCheck.ruleMetadata();
+    }
+
+    @Override
+    public FileInterest validatedFiles() {
+        return codeCheck.validatedFiles();
+    }
+
+    @Override
+    public FileInterest contextFiles() {
+        return codeCheck.contextFiles();
+    }
+
+    @Override
+    public List<Diagnostic> check(ValidationContext context, Path file) {
+        codeCheck.resetCache(file);
+        if (!codeCheck.isResponsible(file)) {
+            return List.of();
+        }
+        return codeCheck.check(file)
+                        .stream()
+                        .map(error -> Diagnostic.fromValidationError(error, id()))
+                        .toList();
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/DefaultRuleRegistry.java
+++ b/src/main/java/de/zorro909/codecheck/validation/DefaultRuleRegistry.java
@@ -1,0 +1,44 @@
+package de.zorro909.codecheck.validation;
+
+import de.zorro909.codecheck.actions.FixAction;
+import de.zorro909.codecheck.checks.CodeCheck;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Singleton
+public class DefaultRuleRegistry implements RuleRegistry {
+
+    private final List<Rule> rules;
+    private final List<Fixer> fixers;
+
+    public DefaultRuleRegistry(List<CodeCheck> codeChecks,
+                               List<FixAction> fixActions) {
+        this.rules = codeChecks == null ? List.of()
+                                        : codeChecks.stream()
+                                                    .map(CodeCheckRuleAdapter::new)
+                                                    .map(Rule.class::cast)
+                                                    .toList();
+        this.fixers = fixActions == null ? List.of()
+                                         : fixActions.stream()
+                                                     .map(FixActionFixerAdapter::new)
+                                                     .map(Fixer.class::cast)
+                                                     .toList();
+    }
+
+    @Override
+    public List<Rule> activeRules() {
+        return rules;
+    }
+
+    @Override
+    public List<Fixer> activeFixers() {
+        return fixers;
+    }
+
+    @Override
+    public WatchPlan watchPlan() {
+        return new WatchPlan(rules.stream().map(Rule::validatedFiles).toList(),
+                             rules.stream().map(Rule::contextFiles).toList());
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/DefaultValidationEngine.java
+++ b/src/main/java/de/zorro909/codecheck/validation/DefaultValidationEngine.java
@@ -1,0 +1,36 @@
+package de.zorro909.codecheck.validation;
+
+import de.zorro909.codecheck.changeset.ChangeSet;
+import jakarta.inject.Singleton;
+
+import java.nio.file.Path;
+import java.util.List;
+
+@Singleton
+public class DefaultValidationEngine implements ValidationEngine {
+
+    private final RuleRegistry ruleRegistry;
+
+    public DefaultValidationEngine(RuleRegistry ruleRegistry) {
+        this.ruleRegistry = ruleRegistry;
+    }
+
+    @Override
+    public ValidationResult validate(ChangeSet changeSet, ValidationMode mode) {
+        List<FileValidationResult> fileResults = changeSet.paths()
+                                                          .map(file -> validateFile(file, mode))
+                                                          .toList();
+        return new ValidationResult(mode, fileResults);
+    }
+
+    @Override
+    public FileValidationResult validateFile(Path file, ValidationMode mode) {
+        ValidationContext context = new ValidationContext(mode);
+        List<Diagnostic> diagnostics = ruleRegistry.activeRules()
+                                                   .stream()
+                                                   .filter(rule -> rule.validatedFiles().matches(file))
+                                                   .flatMap(rule -> rule.check(context, file).stream())
+                                                   .toList();
+        return new FileValidationResult(file, mode, diagnostics);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/Diagnostic.java
+++ b/src/main/java/de/zorro909/codecheck/validation/Diagnostic.java
@@ -1,0 +1,23 @@
+package de.zorro909.codecheck.validation;
+
+import de.zorro909.codecheck.checks.ValidationError;
+
+import java.nio.file.Path;
+
+public record Diagnostic(Path file,
+                         String message,
+                         SourcePosition position,
+                         ValidationError.Severity severity,
+                         DiagnosticKind kind,
+                         RuleId ruleId) {
+
+    public ValidationError toValidationError() {
+        return new ValidationError(file, message, position.toJavaParserPosition(), severity);
+    }
+
+    public static Diagnostic fromValidationError(ValidationError error, RuleId ruleId) {
+        return new Diagnostic(error.filePath(), error.errorMessage(),
+                              SourcePosition.from(error.position()), error.severity(),
+                              DiagnosticKind.RULE_VIOLATION, ruleId);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/DiagnosticKind.java
+++ b/src/main/java/de/zorro909/codecheck/validation/DiagnosticKind.java
@@ -1,0 +1,9 @@
+package de.zorro909.codecheck.validation;
+
+public enum DiagnosticKind {
+    RULE_VIOLATION,
+    PARSE_ERROR,
+    SYMBOL_WARNING,
+    TOOL_WARNING,
+    COVERAGE_FAILURE
+}

--- a/src/main/java/de/zorro909/codecheck/validation/FileInterest.java
+++ b/src/main/java/de/zorro909/codecheck/validation/FileInterest.java
@@ -1,0 +1,35 @@
+package de.zorro909.codecheck.validation;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Predicate;
+
+public record FileInterest(String description,
+                           List<String> includeGlobs,
+                           Predicate<Path> predicate) {
+
+    public FileInterest {
+        includeGlobs = List.copyOf(includeGlobs);
+    }
+
+    public static FileInterest any() {
+        return new FileInterest("all files", List.of("**/*"), _ -> true);
+    }
+
+    public static FileInterest none() {
+        return new FileInterest("no files", List.of(), _ -> false);
+    }
+
+    public static FileInterest javaMainSources() {
+        return new FileInterest("Java main sources", List.of("src/main/java/**/*.java"),
+                                path -> {
+                                    String normalized = path.toString().replace('\\', '/');
+                                    return normalized.contains("src/main/java/")
+                                           && normalized.endsWith(".java");
+                                });
+    }
+
+    public boolean matches(Path path) {
+        return predicate.test(path);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/FileValidationResult.java
+++ b/src/main/java/de/zorro909/codecheck/validation/FileValidationResult.java
@@ -1,0 +1,17 @@
+package de.zorro909.codecheck.validation;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public record FileValidationResult(Path file,
+                                   ValidationMode mode,
+                                   List<Diagnostic> diagnostics) {
+
+    public FileValidationResult {
+        diagnostics = List.copyOf(diagnostics);
+    }
+
+    public boolean passed() {
+        return diagnostics.isEmpty();
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/FixActionFixerAdapter.java
+++ b/src/main/java/de/zorro909/codecheck/validation/FixActionFixerAdapter.java
@@ -1,0 +1,40 @@
+package de.zorro909.codecheck.validation;
+
+import de.zorro909.codecheck.actions.FixAction;
+
+final class FixActionFixerAdapter implements Fixer {
+
+    private final FixAction fixAction;
+
+    FixActionFixerAdapter(FixAction fixAction) {
+        this.fixAction = fixAction;
+    }
+
+    @Override
+    public FixerId id() {
+        return fixAction.fixerId();
+    }
+
+    @Override
+    public FixerMetadata metadata() {
+        return fixAction.fixerMetadata();
+    }
+
+    @Override
+    public boolean canFix(Diagnostic diagnostic) {
+        return fixAction.canFixError(diagnostic.toValidationError());
+    }
+
+    @Override
+    public FixPlan plan(Diagnostic diagnostic) {
+        return new FixPlan(diagnostic, id());
+    }
+
+    @Override
+    public FixResult apply(FixPlan plan) {
+        boolean fixed = fixAction.fixError(plan.diagnostic().toValidationError());
+        return fixed ? FixResult.applied(fixAction.affectedFiles(
+                             plan.diagnostic().toValidationError()))
+                     : FixResult.notApplied("Fix action returned false");
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/FixApplicationService.java
+++ b/src/main/java/de/zorro909/codecheck/validation/FixApplicationService.java
@@ -1,0 +1,54 @@
+package de.zorro909.codecheck.validation;
+
+import de.zorro909.codecheck.actions.PostAction;
+import jakarta.inject.Singleton;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+@Singleton
+public class FixApplicationService {
+
+    private final RuleRegistry ruleRegistry;
+    private final ValidationEngine validationEngine;
+    private final List<PostAction> postActions;
+
+    public FixApplicationService(RuleRegistry ruleRegistry,
+                                 ValidationEngine validationEngine,
+                                 List<PostAction> postActions) {
+        this.ruleRegistry = ruleRegistry;
+        this.validationEngine = validationEngine;
+        this.postActions = postActions == null ? List.of() : List.copyOf(postActions);
+    }
+
+    public FixResult applyUserSelectedFix(Diagnostic diagnostic,
+                                          ValidationMode mode,
+                                          FixerId fixerId) {
+        Fixer fixer = ruleRegistry.activeFixers()
+                                  .stream()
+                                  .filter(candidate -> candidate.id().equals(fixerId))
+                                  .findFirst()
+                                  .orElseThrow(() -> new IllegalArgumentException(
+                                          "Unknown fixer " + fixerId.value()));
+        if (!fixer.availableIn(mode) || !fixer.canFix(diagnostic)) {
+            return FixResult.notApplied("Fixer is unavailable for " + mode);
+        }
+
+        FixResult fixResult = fixer.apply(fixer.plan(diagnostic));
+        if (!fixResult.applied()) {
+            return fixResult;
+        }
+
+        Set<Path> affectedFiles = fixResult.affectedFiles();
+        boolean recheckPassed = affectedFiles.stream()
+                                             .map(file -> validationEngine.validateFile(file, mode))
+                                             .allMatch(FileValidationResult::passed);
+        if (recheckPassed) {
+            postActions.forEach(action -> action.perform(affectedFiles));
+            return fixResult.withRestaged(true);
+        }
+
+        return fixResult.withRestaged(false);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/FixInteraction.java
+++ b/src/main/java/de/zorro909/codecheck/validation/FixInteraction.java
@@ -1,0 +1,6 @@
+package de.zorro909.codecheck.validation;
+
+public enum FixInteraction {
+    NONE,
+    INTERACTIVE
+}

--- a/src/main/java/de/zorro909/codecheck/validation/FixPlan.java
+++ b/src/main/java/de/zorro909/codecheck/validation/FixPlan.java
@@ -1,0 +1,5 @@
+package de.zorro909.codecheck.validation;
+
+public record FixPlan(Diagnostic diagnostic,
+                      FixerId fixerId) {
+}

--- a/src/main/java/de/zorro909/codecheck/validation/FixResult.java
+++ b/src/main/java/de/zorro909/codecheck/validation/FixResult.java
@@ -1,0 +1,26 @@
+package de.zorro909.codecheck.validation;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+public record FixResult(boolean applied,
+                        Set<Path> affectedFiles,
+                        boolean restaged,
+                        String message) {
+
+    public FixResult {
+        affectedFiles = Set.copyOf(affectedFiles);
+    }
+
+    public static FixResult applied(Set<Path> affectedFiles) {
+        return new FixResult(true, affectedFiles, false, "");
+    }
+
+    public static FixResult notApplied(String message) {
+        return new FixResult(false, Set.of(), false, message);
+    }
+
+    public FixResult withRestaged(boolean restaged) {
+        return new FixResult(applied, affectedFiles, restaged, message);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/Fixer.java
+++ b/src/main/java/de/zorro909/codecheck/validation/Fixer.java
@@ -1,0 +1,18 @@
+package de.zorro909.codecheck.validation;
+
+public interface Fixer {
+
+    FixerId id();
+
+    FixerMetadata metadata();
+
+    boolean canFix(Diagnostic diagnostic);
+
+    FixPlan plan(Diagnostic diagnostic);
+
+    FixResult apply(FixPlan plan);
+
+    default boolean availableIn(ValidationMode mode) {
+        return metadata().interaction() != FixInteraction.INTERACTIVE || mode.allowsInteractiveFixers();
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/FixerId.java
+++ b/src/main/java/de/zorro909/codecheck/validation/FixerId.java
@@ -1,0 +1,4 @@
+package de.zorro909.codecheck.validation;
+
+public record FixerId(String value) {
+}

--- a/src/main/java/de/zorro909/codecheck/validation/FixerMetadata.java
+++ b/src/main/java/de/zorro909/codecheck/validation/FixerMetadata.java
@@ -1,0 +1,5 @@
+package de.zorro909.codecheck.validation;
+
+public record FixerMetadata(String name,
+                            FixInteraction interaction) {
+}

--- a/src/main/java/de/zorro909/codecheck/validation/Rule.java
+++ b/src/main/java/de/zorro909/codecheck/validation/Rule.java
@@ -1,0 +1,17 @@
+package de.zorro909.codecheck.validation;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public interface Rule {
+
+    RuleId id();
+
+    RuleMetadata metadata();
+
+    FileInterest validatedFiles();
+
+    FileInterest contextFiles();
+
+    List<Diagnostic> check(ValidationContext context, Path file);
+}

--- a/src/main/java/de/zorro909/codecheck/validation/RuleId.java
+++ b/src/main/java/de/zorro909/codecheck/validation/RuleId.java
@@ -1,0 +1,4 @@
+package de.zorro909.codecheck.validation;
+
+public record RuleId(String value) {
+}

--- a/src/main/java/de/zorro909/codecheck/validation/RuleMetadata.java
+++ b/src/main/java/de/zorro909/codecheck/validation/RuleMetadata.java
@@ -1,0 +1,5 @@
+package de.zorro909.codecheck.validation;
+
+public record RuleMetadata(String name,
+                           String description) {
+}

--- a/src/main/java/de/zorro909/codecheck/validation/RuleRegistry.java
+++ b/src/main/java/de/zorro909/codecheck/validation/RuleRegistry.java
@@ -1,0 +1,16 @@
+package de.zorro909.codecheck.validation;
+
+import java.util.List;
+
+public interface RuleRegistry {
+
+    List<Rule> activeRules();
+
+    List<Fixer> activeFixers();
+
+    WatchPlan watchPlan();
+
+    default List<Fixer> activeFixers(ValidationMode mode) {
+        return activeFixers().stream().filter(fixer -> fixer.availableIn(mode)).toList();
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/SourcePosition.java
+++ b/src/main/java/de/zorro909/codecheck/validation/SourcePosition.java
@@ -1,0 +1,15 @@
+package de.zorro909.codecheck.validation;
+
+import com.github.javaparser.Position;
+
+public record SourcePosition(int line,
+                             int column) {
+
+    public static SourcePosition from(Position position) {
+        return new SourcePosition(position.line, position.column);
+    }
+
+    public Position toJavaParserPosition() {
+        return new Position(line, column);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/ValidationContext.java
+++ b/src/main/java/de/zorro909/codecheck/validation/ValidationContext.java
@@ -1,0 +1,4 @@
+package de.zorro909.codecheck.validation;
+
+public record ValidationContext(ValidationMode mode) {
+}

--- a/src/main/java/de/zorro909/codecheck/validation/ValidationEngine.java
+++ b/src/main/java/de/zorro909/codecheck/validation/ValidationEngine.java
@@ -1,0 +1,12 @@
+package de.zorro909.codecheck.validation;
+
+import de.zorro909.codecheck.changeset.ChangeSet;
+
+import java.nio.file.Path;
+
+public interface ValidationEngine {
+
+    ValidationResult validate(ChangeSet changeSet, ValidationMode mode);
+
+    FileValidationResult validateFile(Path file, ValidationMode mode);
+}

--- a/src/main/java/de/zorro909/codecheck/validation/ValidationMode.java
+++ b/src/main/java/de/zorro909/codecheck/validation/ValidationMode.java
@@ -1,0 +1,12 @@
+package de.zorro909.codecheck.validation;
+
+public enum ValidationMode {
+    ASSISTANT,
+    INTERACTIVE,
+    BATCH,
+    PRE_COMMIT;
+
+    public boolean allowsInteractiveFixers() {
+        return this == ASSISTANT || this == INTERACTIVE;
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/ValidationResult.java
+++ b/src/main/java/de/zorro909/codecheck/validation/ValidationResult.java
@@ -1,0 +1,19 @@
+package de.zorro909.codecheck.validation;
+
+import java.util.List;
+
+public record ValidationResult(ValidationMode mode,
+                               List<FileValidationResult> fileResults) {
+
+    public ValidationResult {
+        fileResults = List.copyOf(fileResults);
+    }
+
+    public List<Diagnostic> diagnostics() {
+        return fileResults.stream().flatMap(result -> result.diagnostics().stream()).toList();
+    }
+
+    public boolean passed() {
+        return diagnostics().isEmpty();
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/validation/WatchPlan.java
+++ b/src/main/java/de/zorro909/codecheck/validation/WatchPlan.java
@@ -1,0 +1,12 @@
+package de.zorro909.codecheck.validation;
+
+import java.util.List;
+
+public record WatchPlan(List<FileInterest> validatedFiles,
+                        List<FileInterest> contextFiles) {
+
+    public WatchPlan {
+        validatedFiles = List.copyOf(validatedFiles);
+        contextFiles = List.copyOf(contextFiles);
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/validation/DefaultValidationEngineTest.java
+++ b/src/test/java/de/zorro909/codecheck/validation/DefaultValidationEngineTest.java
@@ -1,0 +1,115 @@
+package de.zorro909.codecheck.validation;
+
+import com.github.javaparser.Position;
+import de.zorro909.codecheck.changeset.ChangeSet;
+import de.zorro909.codecheck.changeset.ChangeSetEntry;
+import de.zorro909.codecheck.changeset.GitFileStatus;
+import de.zorro909.codecheck.checks.CodeCheck;
+import de.zorro909.codecheck.checks.ValidationError;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultValidationEngineTest {
+
+    @Test
+    void validatesChangeSetWithStructuredDiagnosticsWithoutPrinting() {
+        Path file = Path.of("src/main/java/Example.java");
+        RuleRegistry registry = registry(List.of(new CodeCheck() {
+            @Override
+            public RuleId ruleId() {
+                return new RuleId("test.rule");
+            }
+
+            @Override
+            public boolean isResponsible(Path checkedFile) {
+                return true;
+            }
+
+            @Override
+            public List<ValidationError> check(Path checkedFile) {
+                return List.of(new ValidationError(checkedFile, "structured",
+                                                   new Position(2, 3),
+                                                   ValidationError.Severity.HIGH));
+            }
+
+            @Override
+            public void resetCache(Path checkedFile) {
+            }
+        }), List.of());
+        ValidationEngine engine = new DefaultValidationEngine(registry);
+
+        ValidationResult result = engine.validate(new ChangeSet(List.of(new ChangeSetEntry(
+                file, GitFileStatus.UNKNOWN, false, false, false, false, "test"))),
+                                                  ValidationMode.PRE_COMMIT);
+
+        assertThat(result.mode()).isEqualTo(ValidationMode.PRE_COMMIT);
+        assertThat(result.diagnostics()).singleElement().satisfies(diagnostic -> {
+            assertThat(diagnostic.file()).isEqualTo(file);
+            assertThat(diagnostic.message()).isEqualTo("structured");
+            assertThat(diagnostic.position()).isEqualTo(new SourcePosition(2, 3));
+            assertThat(diagnostic.severity()).isEqualTo(ValidationError.Severity.HIGH);
+            assertThat(diagnostic.kind()).isEqualTo(DiagnosticKind.RULE_VIOLATION);
+            assertThat(diagnostic.ruleId()).isEqualTo(new RuleId("test.rule"));
+        });
+    }
+
+    @Test
+    void ruleInterestFiltersFilesBeforeLegacyResponsibilityCheck() {
+        CountingCheck check = new CountingCheck();
+        RuleRegistry registry = registry(List.of(check), List.of());
+        ValidationEngine engine = new DefaultValidationEngine(registry);
+
+        FileValidationResult result = engine.validateFile(Path.of("README.md"),
+                                                          ValidationMode.INTERACTIVE);
+
+        assertThat(result.diagnostics()).isEmpty();
+        assertThat(check.checkCalls).isZero();
+    }
+
+    @Test
+    void registryWatchPlanIncludesValidatedAndContextInterests() {
+        CodeCheck check = new CountingCheck();
+        RuleRegistry registry = registry(List.of(check), List.of());
+
+        WatchPlan watchPlan = registry.watchPlan();
+
+        assertThat(watchPlan.validatedFiles()).singleElement()
+                                              .satisfies(interest -> assertThat(
+                                                      interest.includeGlobs()).containsExactly(
+                                                      "src/main/java/**/*.java"));
+    }
+
+    private RuleRegistry registry(List<CodeCheck> checks,
+                                  List<de.zorro909.codecheck.actions.FixAction> fixActions) {
+        return new DefaultRuleRegistry(checks, fixActions);
+    }
+
+    private static final class CountingCheck implements CodeCheck {
+
+        private int checkCalls;
+
+        @Override
+        public FileInterest validatedFiles() {
+            return FileInterest.javaMainSources();
+        }
+
+        @Override
+        public boolean isResponsible(Path file) {
+            return true;
+        }
+
+        @Override
+        public List<ValidationError> check(Path file) {
+            checkCalls++;
+            return List.of();
+        }
+
+        @Override
+        public void resetCache(Path file) {
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/validation/FixerRegistryAndApplicationTest.java
+++ b/src/test/java/de/zorro909/codecheck/validation/FixerRegistryAndApplicationTest.java
@@ -1,0 +1,160 @@
+package de.zorro909.codecheck.validation;
+
+import com.github.javaparser.Position;
+import de.zorro909.codecheck.actions.FixAction;
+import de.zorro909.codecheck.actions.PostAction;
+import de.zorro909.codecheck.actions.fix.ManualEditorFixAction;
+import de.zorro909.codecheck.checks.CodeCheck;
+import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.editor.EditorExecutor;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FixerRegistryAndApplicationTest {
+
+    @Test
+    void manualEditorFixActionIsInteractiveAndUnavailableInBatch() {
+        ManualEditorFixAction action = new ManualEditorFixAction(new NoopEditorExecutor());
+        RuleRegistry registry = new DefaultRuleRegistry(List.of(), List.of(action));
+
+        Fixer fixer = registry.activeFixers().get(0);
+
+        assertThat(fixer.metadata().interaction()).isEqualTo(FixInteraction.INTERACTIVE);
+        assertThat(registry.activeFixers(ValidationMode.INTERACTIVE)).containsExactly(fixer);
+        assertThat(registry.activeFixers(ValidationMode.BATCH)).isEmpty();
+        assertThat(registry.activeFixers(ValidationMode.PRE_COMMIT)).isEmpty();
+    }
+
+    @Test
+    void userTriggeredFixRestagesAllAffectedFilesAfterSuccessfulRecheck() {
+        Path source = Path.of("src/main/java/Example.java");
+        Path test = Path.of("src/test/java/ExampleTest.java");
+        Diagnostic diagnostic = diagnostic(source);
+        Set<Path> affectedFiles = Set.of(source, test);
+        FixAction fixAction = new FixAction() {
+            @Override
+            public FixerId fixerId() {
+                return new FixerId("two-file-fix");
+            }
+
+            @Override
+            public boolean canFixError(ValidationError validationError) {
+                return true;
+            }
+
+            @Override
+            public boolean fixError(ValidationError validationError) {
+                return true;
+            }
+
+            @Override
+            public Set<Path> affectedFiles(ValidationError validationError) {
+                return affectedFiles;
+            }
+        };
+        AtomicReference<Set<Path>> restaged = new AtomicReference<>();
+        PostAction postAction = files -> {
+            restaged.set(Set.copyOf(files));
+            return true;
+        };
+        RuleRegistry registry = new DefaultRuleRegistry(List.of(passingCheck()), List.of(fixAction));
+        FixApplicationService service = new FixApplicationService(
+                registry, new DefaultValidationEngine(registry), List.of(postAction));
+
+        FixResult result = service.applyUserSelectedFix(diagnostic, ValidationMode.INTERACTIVE,
+                                                        new FixerId("two-file-fix"));
+
+        assertThat(result.applied()).isTrue();
+        assertThat(result.restaged()).isTrue();
+        assertThat(result.affectedFiles()).containsExactlyInAnyOrderElementsOf(affectedFiles);
+        assertThat(restaged.get()).containsExactlyInAnyOrderElementsOf(affectedFiles);
+    }
+
+    @Test
+    void userTriggeredFixDoesNotRestageWhenAffectedFileRecheckFails() {
+        Path source = Path.of("src/main/java/Example.java");
+        Diagnostic diagnostic = diagnostic(source);
+        AtomicReference<Set<Path>> restaged = new AtomicReference<>();
+        FixAction fixAction = new FixAction() {
+            @Override
+            public FixerId fixerId() {
+                return new FixerId("failing-fix");
+            }
+
+            @Override
+            public boolean canFixError(ValidationError validationError) {
+                return true;
+            }
+
+            @Override
+            public boolean fixError(ValidationError validationError) {
+                return true;
+            }
+        };
+        RuleRegistry registry = new DefaultRuleRegistry(List.of(failingCheck()), List.of(fixAction));
+        FixApplicationService service = new FixApplicationService(
+                registry, new DefaultValidationEngine(registry), List.of(files -> {
+                    restaged.set(files);
+                    return true;
+                }));
+
+        FixResult result = service.applyUserSelectedFix(diagnostic, ValidationMode.INTERACTIVE,
+                                                        new FixerId("failing-fix"));
+
+        assertThat(result.applied()).isTrue();
+        assertThat(result.restaged()).isFalse();
+        assertThat(restaged.get()).isNull();
+    }
+
+    private Diagnostic diagnostic(Path file) {
+        return new Diagnostic(file, "message", new SourcePosition(1, 1),
+                              ValidationError.Severity.LOW, DiagnosticKind.RULE_VIOLATION,
+                              new RuleId("rule"));
+    }
+
+    private CodeCheck passingCheck() {
+        return check(List.of());
+    }
+
+    private CodeCheck failingCheck() {
+        return check(List.of(new ValidationError(Path.of("src/main/java/Example.java"),
+                                                 "still failing", new Position(1, 1),
+                                                 ValidationError.Severity.HIGH)));
+    }
+
+    private CodeCheck check(List<ValidationError> errors) {
+        return new CodeCheck() {
+            @Override
+            public boolean isResponsible(Path file) {
+                return true;
+            }
+
+            @Override
+            public List<ValidationError> check(Path file) {
+                return errors;
+            }
+
+            @Override
+            public void resetCache(Path file) {
+            }
+        };
+    }
+
+    private static final class NoopEditorExecutor implements EditorExecutor {
+        @Override
+        public boolean open(Path path, Position position) {
+            return true;
+        }
+
+        @Override
+        public boolean openAndWait(Path file, Position position) {
+            return true;
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/validation/NoMagicValuesRuleMetadataTest.java
+++ b/src/test/java/de/zorro909/codecheck/validation/NoMagicValuesRuleMetadataTest.java
@@ -1,0 +1,29 @@
+package de.zorro909.codecheck.validation;
+
+import de.zorro909.codecheck.FileLoader;
+import de.zorro909.codecheck.checks.java.code.NoMagicValuesCheck;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoMagicValuesRuleMetadataTest {
+
+    @Test
+    void noMagicValuesCheckIsRepresentedAsJavaMainSourceRule(@TempDir Path tempDir) {
+        NoMagicValuesCheck check = new NoMagicValuesCheck(new FileLoader(tempDir, Optional.empty()));
+        RuleRegistry registry = new DefaultRuleRegistry(List.of(check), List.of());
+
+        Rule rule = registry.activeRules().get(0);
+
+        assertThat(rule.id()).isEqualTo(new RuleId("java.no-magic-values"));
+        assertThat(rule.metadata().name()).isEqualTo("No magic values");
+        assertThat(rule.validatedFiles().includeGlobs()).containsExactly("src/main/java/**/*.java");
+        assertThat(rule.validatedFiles().matches(Path.of("src/main/java/demo/Example.java"))).isTrue();
+        assertThat(rule.validatedFiles().matches(Path.of("src/test/java/demo/ExampleTest.java"))).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- add the CR-005 implementation specification
- introduce structured validation contracts, diagnostics, rule registry, watch plan, validation modes, and validation engine
- adapt existing CodeCheck and FixAction implementations into Rule and Fixer contracts
- represent NoMagicValuesCheck as a Java main-source rule and ManualEditorFixAction as an interactive fixer
- add user-triggered fix application with affected-file recheck and post-action restaging

## Tests
- ./mvnw test