### PR TITLE
CR-006: Java project model and parsing

### DIFF
--- a/docs/implementation-specs/CR-006-java-project-model-and-parsing.md
+++ b/docs/implementation-specs/CR-006-java-project-model-and-parsing.md
@@ -1,0 +1,47 @@
+# CR-006 Implementation Specification: Java Project Model and Parsing
+
+## Scope
+
+This increment introduces a Maven-aware project model and moves JavaParser ownership into a
+dedicated parser service. Existing Java rules continue to extend `JavaChecker`, but `JavaChecker`
+now delegates parsing, parser caches, and symbol diagnostics to `JavaParserService`.
+
+## Project Model
+
+`MavenProjectModelService` builds a model from the repository root:
+
+- root Maven project
+- direct Maven reactor modules from `<modules><module>...`
+- module main and test source roots
+- Maven default generated source and generated test source roots
+- detected language level from configuration
+
+Generated source roots are context roots only. They are not included in validation source roots.
+
+## Parser Service
+
+`DefaultJavaParserService` owns:
+
+- parse cache
+- parser cache
+- module-aware type solver setup
+
+It uses concurrent maps, does not lowercase paths, and supports daemon-safe invalidation by file
+or module.
+
+## Diagnostics
+
+- Parse failures produce `HIGH` `PARSE_ERROR` diagnostics.
+- Unresolved class/interface types produce `MEDIUM` `SYMBOL_WARNING` diagnostics.
+- Parser diagnostics are surfaced through `ParseOutcome` and included in legacy `JavaChecker`
+  validation output.
+
+## Tests
+
+- Multi-module Maven roots are modeled.
+- Generated roots are context-only.
+- Module source files parse with module source roots.
+- Module test files resolve main source types.
+- Generated implementation files can be parsed as context.
+- Parse errors become HIGH diagnostics.
+- Unresolved symbols become MEDIUM diagnostics.

--- a/docs/implementation-specs/CR-006-java-project-model-and-parsing.md
+++ b/docs/implementation-specs/CR-006-java-project-model-and-parsing.md
@@ -45,3 +45,5 @@ or module.
 - Generated implementation files can be parsed as context.
 - Parse errors become HIGH diagnostics.
 - Unresolved symbols become MEDIUM diagnostics.
+- All Java checks share the singleton parser service and its caches.
+- The project model bean resolves through the qualified repository directory path.

--- a/src/main/java/de/zorro909/codecheck/checks/java/JavaChecker.java
+++ b/src/main/java/de/zorro909/codecheck/checks/java/JavaChecker.java
@@ -1,40 +1,26 @@
 package de.zorro909.codecheck.checks.java;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.github.javaparser.JavaParser;
-import com.github.javaparser.ParseResult;
-import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.Position;
-import com.github.javaparser.Problem;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.symbolsolver.JavaSymbolSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 
 import de.zorro909.codecheck.FileLoader;
 import de.zorro909.codecheck.checks.CodeCheck;
 import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.java.DefaultJavaParserService;
+import de.zorro909.codecheck.java.JavaParserService;
+import de.zorro909.codecheck.java.MavenProjectModelService;
+import de.zorro909.codecheck.java.ParseOutcome;
+import de.zorro909.codecheck.validation.Diagnostic;
 
 public abstract class JavaChecker implements CodeCheck {
 
-    private static final Map<Path, ParseResult<CompilationUnit>> classCache = new HashMap<>();
-
-    private static final Map<String, JavaParser> javaParser = new HashMap<>();
-
     public static final String JAVA_FILE_SUFFIX = ".java";
-
-    public static final String PARSE_EXCEPTION = "Big Problem Exception";
 
     public static final String COMP_UNIT_NO_STORAGE = "Invalid compilation unit: storage not found";
 
@@ -47,9 +33,15 @@ public abstract class JavaChecker implements CodeCheck {
         "src" + File.separatorChar + "test" + File.separatorChar + "java";
 
     protected final FileLoader fileLoader;
+    private final JavaParserService javaParserService;
 
     protected JavaChecker(FileLoader fileLoader) {
+        this(fileLoader, new DefaultJavaParserService(new MavenProjectModelService(Path.of(""))));
+    }
+
+    protected JavaChecker(FileLoader fileLoader, JavaParserService javaParserService) {
         this.fileLoader = fileLoader;
+        this.javaParserService = javaParserService;
     }
 
     /**
@@ -76,44 +68,31 @@ public abstract class JavaChecker implements CodeCheck {
 
     @Override
     public List<ValidationError> check(Path path) {
-        ParseResult<CompilationUnit> parseResult = load(path);
-        if (!parseResult.isSuccessful() || parseResult.getResult().isEmpty()) {
-            String errorMessage = "Failure parsing java file: " + parseResult.getProblems()
-                .stream()
-                .map(Problem::toString)
-                .collect(
-                    Collectors.joining(
-                        ", "));
-            return List.of(new ValidationError(path, errorMessage, new Position(Position.FIRST_LINE,
-                Position.FIRST_COLUMN),
-                ValidationError.Severity.HIGH));
+        ParseOutcome parseOutcome = load(path);
+        List<ValidationError> parserDiagnostics = parseOutcome.diagnostics()
+                                                              .stream()
+                                                              .map(Diagnostic::toValidationError)
+                                                              .toList();
+        if (parseOutcome.compilationUnit().isEmpty()) {
+            return parserDiagnostics;
         }
-        return check(parseResult.getResult().get());
+        List<ValidationError> checkDiagnostics = check(parseOutcome.compilationUnit().get());
+        return Stream.concat(parserDiagnostics.stream(), checkDiagnostics.stream()).toList();
     }
 
     /**
      * Loads a Java source file from the specified path and returns a ParseResult of CompilationUnit.
      * @param path The path of the Java source file to load.
-     * @return The ParseResult of CompilationUnit representing the loaded Java source file.
+     * @return The ParseOutcome representing the loaded Java source file.
      */
-    public ParseResult<CompilationUnit> load(Path path) {
-        try {
-            if (classCache.containsKey(path)) {
-                return classCache.get(path);
-            }
-            fileLoader.markFile(path);
-            ParseResult<CompilationUnit> parseResult = getJavaParser(path).parse(path);
-            classCache.put(path, parseResult);
-            return parseResult;
-        } catch (Exception e) {
-            System.err.println("Can't parse File '" + path.toString() + "'! (" + e.toString() + ")");
-            return new ParseResult<>(null, List.of(new Problem(PARSE_EXCEPTION, null, e)), null);
-        }
+    public ParseOutcome load(Path path) {
+        fileLoader.markFile(path);
+        return javaParserService.parse(path);
     }
 
     @Override
     public void resetCache(Path path) {
-        classCache.remove(path);
+        javaParserService.invalidate(path);
     }
 
     protected Path getPath(CompilationUnit javaUnit) {
@@ -125,39 +104,5 @@ public abstract class JavaChecker implements CodeCheck {
         return javaUnit.findAll(ClassOrInterfaceDeclaration.class,
                 clazz -> clazz.getAnnotationByName(GENERATED_ANNOTATION).isEmpty())
             .stream();
-    }
-
-    private JavaParser getJavaParser(Path filePath) {
-        String path = filePath.toAbsolutePath().toString();
-
-        if(path.contains(MAIN_FOLDER)){
-            path = path.substring(0, path.indexOf(MAIN_FOLDER));
-        }else if(path.contains(TEST_FOLDER)){
-            path = path.substring(0, path.indexOf(TEST_FOLDER));
-        }
-        path = path.toLowerCase();
-
-        if(javaParser.containsKey(path)){
-            return javaParser.get(path);
-        }
-
-        CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
-        combinedTypeSolver.add(new ReflectionTypeSolver());
-        Path mainFolder = Path.of(path + MAIN_FOLDER);
-        if(Files.exists(mainFolder)) {
-            combinedTypeSolver.add(new JavaParserTypeSolver(mainFolder));
-        }
-        Path testFolder = Path.of(path + TEST_FOLDER);
-        if(Files.exists(testFolder)) {
-            combinedTypeSolver.add(new JavaParserTypeSolver(testFolder));
-        }
-
-        JavaParser parser = new JavaParser();
-        parser.getParserConfiguration()
-            .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25)
-            .setSymbolResolver(new JavaSymbolSolver(combinedTypeSolver));
-
-        javaParser.put(path, parser);
-        return parser;
     }
 }

--- a/src/main/java/de/zorro909/codecheck/checks/java/code/NoMagicValuesCheck.java
+++ b/src/main/java/de/zorro909/codecheck/checks/java/code/NoMagicValuesCheck.java
@@ -8,9 +8,11 @@ import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import de.zorro909.codecheck.FileLoader;
 import de.zorro909.codecheck.checks.ValidationError;
 import de.zorro909.codecheck.checks.java.JavaChecker;
+import de.zorro909.codecheck.java.JavaParserService;
 import de.zorro909.codecheck.validation.FileInterest;
 import de.zorro909.codecheck.validation.RuleId;
 import de.zorro909.codecheck.validation.RuleMetadata;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import java.io.File;
@@ -31,6 +33,11 @@ public class NoMagicValuesCheck extends JavaChecker {
 
     public NoMagicValuesCheck(FileLoader fileLoader) {
         super(fileLoader);
+    }
+
+    @Inject
+    public NoMagicValuesCheck(FileLoader fileLoader, JavaParserService javaParserService) {
+        super(fileLoader, javaParserService);
     }
 
     @Override

--- a/src/main/java/de/zorro909/codecheck/checks/java/doc/JavaDocCheck.java
+++ b/src/main/java/de/zorro909/codecheck/checks/java/doc/JavaDocCheck.java
@@ -1,5 +1,6 @@
 package de.zorro909.codecheck.checks.java.doc;
 
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import java.io.File;
@@ -30,6 +31,7 @@ import com.github.javaparser.resolution.UnsolvedSymbolException;
 import de.zorro909.codecheck.FileLoader;
 import de.zorro909.codecheck.checks.ValidationError;
 import de.zorro909.codecheck.checks.java.JavaChecker;
+import de.zorro909.codecheck.java.JavaParserService;
 import de.zorro909.codecheck.utils.MethodDeclarationExtensions;
 
 /**
@@ -60,6 +62,11 @@ public final class JavaDocCheck extends JavaChecker {
 
     public JavaDocCheck(FileLoader fileLoader) {
         super(fileLoader);
+    }
+
+    @Inject
+    public JavaDocCheck(FileLoader fileLoader, JavaParserService javaParserService) {
+        super(fileLoader, javaParserService);
     }
 
     @Override

--- a/src/main/java/de/zorro909/codecheck/checks/java/test/PublicMethodsAreTestedCheck.java
+++ b/src/main/java/de/zorro909/codecheck/checks/java/test/PublicMethodsAreTestedCheck.java
@@ -1,5 +1,6 @@
 package de.zorro909.codecheck.checks.java.test;
 
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import java.nio.file.Files;
@@ -17,6 +18,7 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import de.zorro909.codecheck.FileLoader;
 import de.zorro909.codecheck.checks.ValidationError;
 import de.zorro909.codecheck.checks.java.JavaChecker;
+import de.zorro909.codecheck.java.JavaParserService;
 import de.zorro909.codecheck.java.ParseOutcome;
 import de.zorro909.codecheck.utils.CompilationUnitExtensions;
 import de.zorro909.codecheck.utils.MethodDeclarationExtensions;
@@ -29,6 +31,12 @@ public class PublicMethodsAreTestedCheck extends JavaChecker {
 
     protected PublicMethodsAreTestedCheck(FileLoader fileLoader) {
         super(fileLoader);
+    }
+
+    @Inject
+    public PublicMethodsAreTestedCheck(FileLoader fileLoader,
+                                       JavaParserService javaParserService) {
+        super(fileLoader, javaParserService);
     }
 
     @Override

--- a/src/main/java/de/zorro909/codecheck/checks/java/test/PublicMethodsAreTestedCheck.java
+++ b/src/main/java/de/zorro909/codecheck/checks/java/test/PublicMethodsAreTestedCheck.java
@@ -9,7 +9,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Predicate;
 
-import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -18,6 +17,7 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import de.zorro909.codecheck.FileLoader;
 import de.zorro909.codecheck.checks.ValidationError;
 import de.zorro909.codecheck.checks.java.JavaChecker;
+import de.zorro909.codecheck.java.ParseOutcome;
 import de.zorro909.codecheck.utils.CompilationUnitExtensions;
 import de.zorro909.codecheck.utils.MethodDeclarationExtensions;
 
@@ -51,12 +51,12 @@ public class PublicMethodsAreTestedCheck extends JavaChecker {
             return new ArrayList<>();
         }
 
-        ParseResult<CompilationUnit> testUnitResult = load(filePath);
-        if (!testUnitResult.isSuccessful()) {
+        ParseOutcome testUnitResult = load(filePath);
+        if (testUnitResult.compilationUnit().isEmpty()) {
             return new ArrayList<>();
         }
 
-        CompilationUnit testUnit = testUnitResult.getResult().get();
+        CompilationUnit testUnit = testUnitResult.compilationUnit().get();
 
         testUnit.findAll(MethodCallExpr.class).stream().filter(MethodCallExpr::hasScope).forEach(callExpr -> {
             String name = callExpr.getNameAsString();

--- a/src/main/java/de/zorro909/codecheck/checks/java/test/TestClassCheck.java
+++ b/src/main/java/de/zorro909/codecheck/checks/java/test/TestClassCheck.java
@@ -4,7 +4,9 @@ import com.github.javaparser.ast.CompilationUnit;
 import de.zorro909.codecheck.FileLoader;
 import de.zorro909.codecheck.checks.ValidationError;
 import de.zorro909.codecheck.checks.java.JavaChecker;
+import de.zorro909.codecheck.java.JavaParserService;
 import de.zorro909.codecheck.utils.CompilationUnitExtensions;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import java.io.File;
@@ -28,6 +30,11 @@ public class TestClassCheck extends JavaChecker {
 
     public TestClassCheck(FileLoader fileLoader) {
         super(fileLoader);
+    }
+
+    @Inject
+    public TestClassCheck(FileLoader fileLoader, JavaParserService javaParserService) {
+        super(fileLoader, javaParserService);
     }
 
     @Override

--- a/src/main/java/de/zorro909/codecheck/java/DefaultJavaParserService.java
+++ b/src/main/java/de/zorro909/codecheck/java/DefaultJavaParserService.java
@@ -1,0 +1,169 @@
+package de.zorro909.codecheck.java;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.Position;
+import com.github.javaparser.Problem;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.validation.Diagnostic;
+import de.zorro909.codecheck.validation.DiagnosticKind;
+import de.zorro909.codecheck.validation.RuleId;
+import de.zorro909.codecheck.validation.SourcePosition;
+import jakarta.inject.Singleton;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Stream;
+
+@Singleton
+public class DefaultJavaParserService implements JavaParserService {
+
+    private static final RuleId JAVA_PARSER_RULE = new RuleId("java.parser");
+
+    private final ProjectModelService projectModelService;
+    private final ConcurrentMap<Path, ParseOutcome> parseCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<ModuleId, JavaParser> parserCache = new ConcurrentHashMap<>();
+
+    public DefaultJavaParserService(ProjectModelService projectModelService) {
+        this.projectModelService = projectModelService;
+    }
+
+    @Override
+    public ParseOutcome parse(Path file) {
+        Path absolute = file.toAbsolutePath().normalize();
+        return parseCache.computeIfAbsent(absolute, this::parseUncached);
+    }
+
+    @Override
+    public Optional<CompilationUnit> compilationUnit(Path file) {
+        return parse(file).compilationUnit();
+    }
+
+    @Override
+    public void invalidate(Path file) {
+        parseCache.remove(file.toAbsolutePath().normalize());
+    }
+
+    @Override
+    public void invalidateModule(ModuleId moduleId) {
+        parserCache.remove(moduleId);
+        ProjectModel model = projectModelService.currentModel();
+        model.modules()
+             .stream()
+             .filter(module -> module.id().equals(moduleId))
+             .findFirst()
+             .ifPresent(module -> parseCache.keySet().removeIf(module::owns));
+    }
+
+    private ParseOutcome parseUncached(Path file) {
+        ProjectModel model = projectModelService.currentModel();
+        MavenModule module = model.moduleFor(file).orElseGet(() -> model.modules().getFirst());
+        try {
+            ParseResult<CompilationUnit> result = parserFor(module, model).parse(file);
+            if (!result.isSuccessful() || result.getResult().isEmpty()) {
+                return new ParseOutcome(file, Optional.empty(), parseDiagnostics(file, result));
+            }
+            CompilationUnit compilationUnit = result.getResult().get();
+            List<Diagnostic> diagnostics = new ArrayList<>();
+            diagnostics.addAll(parseDiagnostics(file, result));
+            diagnostics.addAll(symbolDiagnostics(file, compilationUnit));
+            return new ParseOutcome(file, Optional.of(compilationUnit), diagnostics);
+        } catch (Exception e) {
+            return new ParseOutcome(file, Optional.empty(), List.of(new Diagnostic(
+                    file, "Failure parsing java file: " + e.getMessage(),
+                    new SourcePosition(Position.FIRST_LINE, Position.FIRST_COLUMN),
+                    ValidationError.Severity.HIGH, DiagnosticKind.PARSE_ERROR,
+                    JAVA_PARSER_RULE)));
+        }
+    }
+
+    private JavaParser parserFor(MavenModule module, ProjectModel model) {
+        return parserCache.computeIfAbsent(module.id(), _ -> {
+            CombinedTypeSolver typeSolver = new CombinedTypeSolver();
+            typeSolver.add(new ReflectionTypeSolver());
+            Stream.of(module.sourceRoots(), module.testRoots(), module.generatedSourceRoots(),
+                      module.generatedTestSourceRoots())
+                  .flatMap(List::stream)
+                  .filter(Files::exists)
+                  .forEach(root -> typeSolver.add(new JavaParserTypeSolver(root)));
+            ParserConfiguration configuration = new ParserConfiguration()
+                    .setLanguageLevel(languageLevel(model.languageLevel()))
+                    .setSymbolResolver(new JavaSymbolSolver(typeSolver));
+            return new JavaParser(configuration);
+        });
+    }
+
+    private ParserConfiguration.LanguageLevel languageLevel(int languageLevel) {
+        return switch (languageLevel) {
+            case 8 -> ParserConfiguration.LanguageLevel.JAVA_8;
+            case 9 -> ParserConfiguration.LanguageLevel.JAVA_9;
+            case 10 -> ParserConfiguration.LanguageLevel.JAVA_10;
+            case 11 -> ParserConfiguration.LanguageLevel.JAVA_11;
+            case 12 -> ParserConfiguration.LanguageLevel.JAVA_12;
+            case 13 -> ParserConfiguration.LanguageLevel.JAVA_13;
+            case 14 -> ParserConfiguration.LanguageLevel.JAVA_14;
+            case 15 -> ParserConfiguration.LanguageLevel.JAVA_15;
+            case 16 -> ParserConfiguration.LanguageLevel.JAVA_16;
+            case 17 -> ParserConfiguration.LanguageLevel.JAVA_17;
+            case 18 -> ParserConfiguration.LanguageLevel.JAVA_18;
+            case 19 -> ParserConfiguration.LanguageLevel.JAVA_19;
+            case 20 -> ParserConfiguration.LanguageLevel.JAVA_20;
+            case 21 -> ParserConfiguration.LanguageLevel.JAVA_21;
+            default -> ParserConfiguration.LanguageLevel.JAVA_25;
+        };
+    }
+
+    private List<Diagnostic> parseDiagnostics(Path file, ParseResult<CompilationUnit> result) {
+        return result.getProblems()
+                     .stream()
+                     .map(problem -> parseDiagnostic(file, problem))
+                     .toList();
+    }
+
+    private Diagnostic parseDiagnostic(Path file, Problem problem) {
+        SourcePosition position = problem.getLocation()
+                                         .map(location -> location.getBegin())
+                                         .flatMap(token -> token.getRange())
+                                         .map(range -> range.begin)
+                                         .map(SourcePosition::from)
+                                         .orElse(new SourcePosition(1, 1));
+        return new Diagnostic(file, "Failure parsing java file: " + problem.getMessage(),
+                              position, ValidationError.Severity.HIGH,
+                              DiagnosticKind.PARSE_ERROR, JAVA_PARSER_RULE);
+    }
+
+    private List<Diagnostic> symbolDiagnostics(Path file, CompilationUnit compilationUnit) {
+        List<Diagnostic> diagnostics = new ArrayList<>();
+        for (ClassOrInterfaceType type : compilationUnit.findAll(ClassOrInterfaceType.class)) {
+            try {
+                type.resolve();
+            } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
+                diagnostics.add(new Diagnostic(file,
+                                               "Unresolved symbol '" + type.getNameAsString()
+                                               + "': " + e.getMessage(),
+                                               type.getBegin().map(SourcePosition::from)
+                                                   .orElse(new SourcePosition(1, 1)),
+                                               ValidationError.Severity.MEDIUM,
+                                               DiagnosticKind.SYMBOL_WARNING,
+                                               JAVA_PARSER_RULE));
+            } catch (RuntimeException ignored) {
+                // JavaParser can throw for constructs it cannot model yet. Those are not
+                // unresolved-symbol diagnostics.
+            }
+        }
+        return diagnostics;
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/java/JavaParserService.java
+++ b/src/main/java/de/zorro909/codecheck/java/JavaParserService.java
@@ -1,0 +1,17 @@
+package de.zorro909.codecheck.java;
+
+import com.github.javaparser.ast.CompilationUnit;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+public interface JavaParserService {
+
+    ParseOutcome parse(Path file);
+
+    Optional<CompilationUnit> compilationUnit(Path file);
+
+    void invalidate(Path file);
+
+    void invalidateModule(ModuleId moduleId);
+}

--- a/src/main/java/de/zorro909/codecheck/java/MavenModule.java
+++ b/src/main/java/de/zorro909/codecheck/java/MavenModule.java
@@ -1,0 +1,41 @@
+package de.zorro909.codecheck.java;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public record MavenModule(ModuleId id,
+                          Path moduleRoot,
+                          List<Path> sourceRoots,
+                          List<Path> testRoots,
+                          List<Path> generatedSourceRoots,
+                          List<Path> generatedTestSourceRoots) {
+
+    public MavenModule {
+        moduleRoot = moduleRoot.toAbsolutePath().normalize();
+        sourceRoots = normalize(sourceRoots);
+        testRoots = normalize(testRoots);
+        generatedSourceRoots = normalize(generatedSourceRoots);
+        generatedTestSourceRoots = normalize(generatedTestSourceRoots);
+    }
+
+    public List<Path> validationSourceRoots() {
+        return java.util.stream.Stream.concat(sourceRoots.stream(), testRoots.stream()).toList();
+    }
+
+    public List<Path> contextRoots() {
+        return java.util.stream.Stream.concat(generatedSourceRoots.stream(),
+                                             generatedTestSourceRoots.stream()).toList();
+    }
+
+    public boolean owns(Path file) {
+        Path absolute = file.toAbsolutePath().normalize();
+        return java.util.stream.Stream.of(sourceRoots, testRoots, generatedSourceRoots,
+                                          generatedTestSourceRoots)
+                                     .flatMap(List::stream)
+                                     .anyMatch(root -> absolute.startsWith(root));
+    }
+
+    private static List<Path> normalize(List<Path> paths) {
+        return paths.stream().map(path -> path.toAbsolutePath().normalize()).toList();
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/java/MavenProjectModelService.java
+++ b/src/main/java/de/zorro909/codecheck/java/MavenProjectModelService.java
@@ -1,6 +1,9 @@
 package de.zorro909.codecheck.java;
 
+import de.zorro909.codecheck.RepositoryPathProvider;
 import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -20,7 +23,10 @@ public class MavenProjectModelService implements ProjectModelService {
     private final CodeCheckConfigLoader configLoader;
     private volatile ProjectModel currentModel;
 
-    public MavenProjectModelService(Path repositoryRoot, CodeCheckConfigLoader configLoader) {
+    @Inject
+    public MavenProjectModelService(
+            @Named(RepositoryPathProvider.REPOSITORY_DIRECTORY) Path repositoryRoot,
+            CodeCheckConfigLoader configLoader) {
         this.repositoryRoot = repositoryRoot.toAbsolutePath().normalize();
         this.configLoader = configLoader;
     }

--- a/src/main/java/de/zorro909/codecheck/java/MavenProjectModelService.java
+++ b/src/main/java/de/zorro909/codecheck/java/MavenProjectModelService.java
@@ -1,0 +1,90 @@
+package de.zorro909.codecheck.java;
+
+import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import jakarta.inject.Singleton;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Singleton
+public class MavenProjectModelService implements ProjectModelService {
+
+    private final Path repositoryRoot;
+    private final CodeCheckConfigLoader configLoader;
+    private volatile ProjectModel currentModel;
+
+    public MavenProjectModelService(Path repositoryRoot, CodeCheckConfigLoader configLoader) {
+        this.repositoryRoot = repositoryRoot.toAbsolutePath().normalize();
+        this.configLoader = configLoader;
+    }
+
+    public MavenProjectModelService(Path repositoryRoot) {
+        this(repositoryRoot, CodeCheckConfigLoader.defaultsOnly());
+    }
+
+    @Override
+    public ProjectModel currentModel() {
+        ProjectModel model = currentModel;
+        if (model == null) {
+            model = refresh();
+        }
+        return model;
+    }
+
+    @Override
+    public ProjectModel refresh() {
+        int languageLevel = configLoader.load().javaProject().languageLevel();
+        ProjectModel model = new ProjectModel(repositoryRoot, repositoryRoot,
+                                              discoverModules(), languageLevel);
+        currentModel = model;
+        return model;
+    }
+
+    private List<MavenModule> discoverModules() {
+        Set<Path> moduleRoots = new LinkedHashSet<>();
+        moduleRoots.add(repositoryRoot);
+        moduleRoots.addAll(readConfiguredModules(repositoryRoot.resolve("pom.xml")));
+        return moduleRoots.stream().map(this::module).toList();
+    }
+
+    private List<Path> readConfiguredModules(Path pom) {
+        if (!Files.exists(pom)) {
+            return List.of();
+        }
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            Element document = factory.newDocumentBuilder().parse(pom.toFile()).getDocumentElement();
+            NodeList moduleNodes = document.getElementsByTagName("module");
+            List<Path> modules = new ArrayList<>();
+            for (int i = 0; i < moduleNodes.getLength(); i++) {
+                String modulePath = moduleNodes.item(i).getTextContent().trim();
+                if (!modulePath.isEmpty()) {
+                    modules.add(repositoryRoot.resolve(modulePath).normalize());
+                }
+            }
+            return modules;
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to read Maven modules from " + pom, e);
+        }
+    }
+
+    private MavenModule module(Path moduleRoot) {
+        String relative = repositoryRoot.equals(moduleRoot)
+                          ? "."
+                          : repositoryRoot.relativize(moduleRoot).toString();
+        return new MavenModule(new ModuleId(relative), moduleRoot,
+                               List.of(moduleRoot.resolve("src/main/java")),
+                               List.of(moduleRoot.resolve("src/test/java")),
+                               List.of(moduleRoot.resolve("target/generated-sources/annotations")),
+                               List.of(moduleRoot.resolve(
+                                       "target/generated-test-sources/test-annotations")));
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/java/ModuleId.java
+++ b/src/main/java/de/zorro909/codecheck/java/ModuleId.java
@@ -1,0 +1,4 @@
+package de.zorro909.codecheck.java;
+
+public record ModuleId(String value) {
+}

--- a/src/main/java/de/zorro909/codecheck/java/ParseOutcome.java
+++ b/src/main/java/de/zorro909/codecheck/java/ParseOutcome.java
@@ -1,0 +1,25 @@
+package de.zorro909.codecheck.java;
+
+import com.github.javaparser.ast.CompilationUnit;
+import de.zorro909.codecheck.validation.Diagnostic;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+public record ParseOutcome(Path file,
+                           Optional<CompilationUnit> compilationUnit,
+                           List<Diagnostic> diagnostics) {
+
+    public ParseOutcome {
+        file = file.toAbsolutePath().normalize();
+        diagnostics = List.copyOf(diagnostics);
+    }
+
+    public boolean parsed() {
+        return compilationUnit.isPresent()
+               && diagnostics.stream()
+                             .noneMatch(diagnostic -> diagnostic.kind()
+                                                      == de.zorro909.codecheck.validation.DiagnosticKind.PARSE_ERROR);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/java/ProjectModel.java
+++ b/src/main/java/de/zorro909/codecheck/java/ProjectModel.java
@@ -1,0 +1,25 @@
+package de.zorro909.codecheck.java;
+
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+public record ProjectModel(Path repositoryRoot,
+                           Path mavenRoot,
+                           List<MavenModule> modules,
+                           int languageLevel) {
+
+    public ProjectModel {
+        repositoryRoot = repositoryRoot.toAbsolutePath().normalize();
+        mavenRoot = mavenRoot.toAbsolutePath().normalize();
+        modules = List.copyOf(modules);
+    }
+
+    public Optional<MavenModule> moduleFor(Path file) {
+        Path absolute = file.toAbsolutePath().normalize();
+        return modules.stream()
+                      .filter(module -> module.owns(absolute))
+                      .max(Comparator.comparingInt(module -> module.moduleRoot().getNameCount()));
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/java/ProjectModelService.java
+++ b/src/main/java/de/zorro909/codecheck/java/ProjectModelService.java
@@ -1,0 +1,8 @@
+package de.zorro909.codecheck.java;
+
+public interface ProjectModelService {
+
+    ProjectModel currentModel();
+
+    ProjectModel refresh();
+}

--- a/src/test/java/de/zorro909/codecheck/checks/java/JavaCheckerSharedParserTest.java
+++ b/src/test/java/de/zorro909/codecheck/checks/java/JavaCheckerSharedParserTest.java
@@ -1,0 +1,49 @@
+package de.zorro909.codecheck.checks.java;
+
+import de.zorro909.codecheck.FileLoader;
+import de.zorro909.codecheck.checks.CodeCheck;
+import de.zorro909.codecheck.java.JavaParserService;
+import de.zorro909.codecheck.java.ParseOutcome;
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaCheckerSharedParserTest {
+
+    @Test
+    void allJavaCheckersShareTheSingletonParserService(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("Sample.java");
+        Files.writeString(file, "class Sample {}");
+
+        try (ApplicationContext context = ApplicationContext.builder()
+                                                            .singletons(new String[0],
+                                                                        new FileLoader(
+                                                                                Path.of(""),
+                                                                                Optional.empty()))
+                                                            .start()) {
+            JavaParserService parserService = context.getBean(JavaParserService.class);
+            ParseOutcome expected = parserService.parse(file);
+
+            List<JavaChecker> checkers = context.getBeansOfType(CodeCheck.class)
+                                                .stream()
+                                                .filter(JavaChecker.class::isInstance)
+                                                .map(JavaChecker.class::cast)
+                                                .toList();
+
+            assertThat(checkers).isNotEmpty();
+            for (JavaChecker checker : checkers) {
+                assertThat(checker.load(file))
+                        .as(checker.getClass().getSimpleName()
+                            + " should reuse the singleton parser cache")
+                        .isSameAs(expected);
+            }
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/java/DefaultJavaParserServiceTest.java
+++ b/src/test/java/de/zorro909/codecheck/java/DefaultJavaParserServiceTest.java
@@ -1,0 +1,154 @@
+package de.zorro909.codecheck.java;
+
+import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import de.zorro909.codecheck.validation.DiagnosticKind;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultJavaParserServiceTest {
+
+    @Test
+    void parsesModuleSourceFileWithModuleSourceRoots(@TempDir Path repo) throws Exception {
+        writeRootPom(repo, "service");
+        Path source = write(repo, "service/src/main/java/com/example/User.java", """
+                package com.example;
+                public class User {}
+                """);
+        JavaParserService parserService = parserService(repo);
+
+        ParseOutcome outcome = parserService.parse(source);
+
+        assertThat(outcome.compilationUnit()).isPresent();
+        assertThat(outcome.diagnostics()).isEmpty();
+    }
+
+    @Test
+    void moduleTestFileResolvesMainSourceTypes(@TempDir Path repo) throws Exception {
+        writeRootPom(repo, "service");
+        write(repo, "service/src/main/java/com/example/User.java", """
+                package com.example;
+                public class User {}
+                """);
+        Path test = write(repo, "service/src/test/java/com/example/UserTest.java", """
+                package com.example;
+                class UserTest {
+                    User user;
+                }
+                """);
+        JavaParserService parserService = parserService(repo);
+
+        ParseOutcome outcome = parserService.parse(test);
+
+        assertThat(outcome.compilationUnit()).isPresent();
+        assertThat(outcome.diagnostics()).noneMatch(diagnostic -> diagnostic.kind()
+                                                                 == DiagnosticKind.SYMBOL_WARNING);
+    }
+
+    @Test
+    void generatedImplementationCanBeParsedAsContext(@TempDir Path repo) throws Exception {
+        writeRootPom(repo, "service");
+        Path generated = write(repo,
+                               "service/target/generated-sources/annotations/com/example/UserMapperImpl.java",
+                               """
+                                       package com.example;
+                                       public class UserMapperImpl {}
+                                       """);
+        JavaParserService parserService = parserService(repo);
+
+        ParseOutcome outcome = parserService.parse(generated);
+
+        assertThat(outcome.compilationUnit()).isPresent();
+        assertThat(outcome.diagnostics()).isEmpty();
+    }
+
+    @Test
+    void parseFailureBecomesHighParseDiagnostic(@TempDir Path repo) throws Exception {
+        writeRootPom(repo, "service");
+        Path broken = write(repo, "service/src/main/java/com/example/Broken.java", """
+                package com.example;
+                public class Broken {
+                """);
+        JavaParserService parserService = parserService(repo);
+
+        ParseOutcome outcome = parserService.parse(broken);
+
+        assertThat(outcome.compilationUnit()).isEmpty();
+        assertThat(outcome.diagnostics()).anySatisfy(diagnostic -> {
+            assertThat(diagnostic.kind()).isEqualTo(DiagnosticKind.PARSE_ERROR);
+            assertThat(diagnostic.severity())
+                    .isEqualTo(de.zorro909.codecheck.checks.ValidationError.Severity.HIGH);
+        });
+    }
+
+    @Test
+    void unresolvedSymbolBecomesMediumSymbolWarning(@TempDir Path repo) throws Exception {
+        writeRootPom(repo, "service");
+        Path source = write(repo, "service/src/main/java/com/example/NeedsMissingType.java", """
+                package com.example;
+                public class NeedsMissingType {
+                    MissingType missing;
+                }
+                """);
+        JavaParserService parserService = parserService(repo);
+
+        ParseOutcome outcome = parserService.parse(source);
+
+        assertThat(outcome.compilationUnit()).isPresent();
+        assertThat(outcome.diagnostics()).anySatisfy(diagnostic -> {
+            assertThat(diagnostic.kind()).isEqualTo(DiagnosticKind.SYMBOL_WARNING);
+            assertThat(diagnostic.severity())
+                    .isEqualTo(de.zorro909.codecheck.checks.ValidationError.Severity.MEDIUM);
+            assertThat(diagnostic.message()).contains("MissingType");
+        });
+    }
+
+    @Test
+    void invalidateRemovesCachedParseOutcome(@TempDir Path repo) throws Exception {
+        writeRootPom(repo, "service");
+        Path source = write(repo, "service/src/main/java/com/example/Reparsed.java", """
+                package com.example;
+                public class Reparsed {}
+                """);
+        JavaParserService parserService = parserService(repo);
+        ParseOutcome first = parserService.parse(source);
+
+        parserService.invalidate(source);
+        ParseOutcome second = parserService.parse(source);
+
+        assertThat(second).isNotSameAs(first);
+    }
+
+    private JavaParserService parserService(Path repo) {
+        return new DefaultJavaParserService(new MavenProjectModelService(
+                repo, CodeCheckConfigLoader.defaultsOnly()));
+    }
+
+    private void writeRootPom(Path repo, String module) throws Exception {
+        Files.writeString(repo.resolve("pom.xml"), """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId>
+                  <artifactId>root</artifactId>
+                  <version>1</version>
+                  <modules>
+                    <module>%s</module>
+                  </modules>
+                </project>
+                """.formatted(module));
+        Files.createDirectories(repo.resolve(module));
+        Files.writeString(repo.resolve(module).resolve("pom.xml"),
+                          "<project><modelVersion>4.0.0</modelVersion></project>");
+    }
+
+    private Path write(Path repo, String relativePath, String content) throws Exception {
+        Path file = repo.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content);
+        return file;
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/java/MavenProjectModelServiceBeanTest.java
+++ b/src/test/java/de/zorro909/codecheck/java/MavenProjectModelServiceBeanTest.java
@@ -1,0 +1,18 @@
+package de.zorro909.codecheck.java;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MavenProjectModelServiceBeanTest {
+
+    @Test
+    void projectModelServiceBeanResolvesMavenImplementation() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ProjectModelService service = context.getBean(ProjectModelService.class);
+
+            assertThat(service).isInstanceOf(MavenProjectModelService.class);
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/java/MavenProjectModelServiceTest.java
+++ b/src/test/java/de/zorro909/codecheck/java/MavenProjectModelServiceTest.java
@@ -1,0 +1,88 @@
+package de.zorro909.codecheck.java;
+
+import de.zorro909.codecheck.config.CodeCheckConfig;
+import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import de.zorro909.codecheck.config.ConfigOverrides;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MavenProjectModelServiceTest {
+
+    @Test
+    void discoversRootAndMultiModuleMavenSourceRoots(@TempDir Path repo) throws Exception {
+        writePom(repo, """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId>
+                  <artifactId>root</artifactId>
+                  <version>1</version>
+                  <modules>
+                    <module>service-a</module>
+                    <module>service-b</module>
+                  </modules>
+                </project>
+                """);
+        writePom(repo.resolve("service-a"), "<project><modelVersion>4.0.0</modelVersion></project>");
+        writePom(repo.resolve("service-b"), "<project><modelVersion>4.0.0</modelVersion></project>");
+
+        ProjectModel model = new MavenProjectModelService(repo, loader(21)).currentModel();
+
+        assertThat(model.languageLevel()).isEqualTo(21);
+        assertThat(model.modules()).extracting(module -> module.id().value())
+                                   .containsExactly(".", "service-a", "service-b");
+        MavenModule serviceA = model.modules()
+                                    .stream()
+                                    .filter(module -> module.id().equals(new ModuleId("service-a")))
+                                    .findFirst()
+                                    .orElseThrow();
+        assertThat(serviceA.sourceRoots()).contains(repo.resolve("service-a/src/main/java")
+                                                        .toAbsolutePath().normalize());
+        assertThat(serviceA.testRoots()).contains(repo.resolve("service-a/src/test/java")
+                                                      .toAbsolutePath().normalize());
+    }
+
+    @Test
+    void generatedSourceRootsAreContextOnly(@TempDir Path repo) throws Exception {
+        writePom(repo, "<project><modelVersion>4.0.0</modelVersion></project>");
+
+        MavenModule module = new MavenProjectModelService(repo, loader(25)).currentModel()
+                                                                         .modules()
+                                                                         .getFirst();
+
+        Path generated = repo.resolve("target/generated-sources/annotations")
+                             .toAbsolutePath()
+                             .normalize();
+        assertThat(module.generatedSourceRoots()).contains(generated);
+        assertThat(module.contextRoots()).contains(generated);
+        assertThat(module.validationSourceRoots()).doesNotContain(generated);
+    }
+
+    private void writePom(Path directory, String xml) throws Exception {
+        Files.createDirectories(directory);
+        Files.writeString(directory.resolve("pom.xml"), xml);
+    }
+
+    private CodeCheckConfigLoader loader(int languageLevel) {
+        CodeCheckConfig config = CodeCheckConfig.defaults()
+                                               .withJavaProject(new CodeCheckConfig.JavaProject(
+                                                       languageLevel,
+                                                       CodeCheckConfig.GeneratedSourceDetection.MAVEN_DEFAULTS));
+        return new CodeCheckConfigLoader() {
+            @Override
+            public CodeCheckConfig load() {
+                return config;
+            }
+
+            @Override
+            public CodeCheckConfig load(ConfigOverrides overrides) {
+                return overrides.apply(config);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add the CR-006 implementation specification
- introduce Maven project model services with multi-module roots and generated-source context roots
- add JavaParserService with concurrent parse/parser caches and module invalidation
- move JavaChecker parsing through ParseOutcome instead of static parser/cache maps
- surface parse failures as HIGH parse diagnostics and unresolved symbols as MEDIUM symbol warnings

## Tests
- ./mvnw test