### PR TITLE
CR-007: Watcher and incremental state

### DIFF
--- a/docs/implementation-specs/CR-007-watcher-and-incremental-state.md
+++ b/docs/implementation-specs/CR-007-watcher-and-incremental-state.md
@@ -1,0 +1,61 @@
+# CR-007 Implementation Specification: Watcher and Incremental State
+
+## Scope
+
+This increment introduces rule-driven watch planning, configurable debounce primitives, latest
+validation state storage, dependency invalidation, and config-change restart signaling. The existing
+JDK `WatchService` remains the file event source, but its debounce duration now comes from config.
+
+## Watch Scope
+
+`WatchScopeService` combines:
+
+- active rule validated/context interests from `RuleRegistry.watchPlan()`
+- Maven module source/test roots from `ProjectModel`
+- generated source/test roots as context roots
+- root and module `pom.xml` files
+- user and repository config files
+
+Generated roots are context watches, not validation watches.
+
+## Debounce
+
+`DebouncedFileUpdateScheduler` is a deterministic debounce primitive used by tests and intended for
+the watcher. It tracks pending paths and releases them only after the configured save debounce.
+Pre-commit/full scan paths bypass this scheduler by invoking `ChangeSetService` and
+`ValidationEngine` directly.
+
+## Incremental State
+
+`IncrementalValidationState` stores latest diagnostics and status by file:
+
+- `STALE`
+- `CHECKING`
+- `CURRENT`
+
+No history is retained.
+
+## Dependency Invalidation
+
+`DependencyInvalidationGraph` stores edges as:
+
+```text
+context file -> dependent validated file
+```
+
+When a context file changes, all dependents are marked stale.
+
+## Config Changes
+
+`ConfigChangeRestartSignal` recognizes user and repo config paths and raises
+`DaemonRestartRequiredException`. Later daemon lifecycle work can catch this and perform the clean
+restart/reattach loop.
+
+## Tests
+
+- Rule interest in `pom.xml` adds POM files to the watch scope.
+- Java source interests add module Java roots as validation watches.
+- Generated roots are watched as context only.
+- Debounced saves release paths only after configured debounce.
+- Context changes mark dependent files stale.
+- Config changes raise restart-required.

--- a/src/main/java/de/zorro909/codecheck/daemon/FileWatcher.java
+++ b/src/main/java/de/zorro909/codecheck/daemon/FileWatcher.java
@@ -8,6 +8,7 @@ import jakarta.inject.Singleton;
 
 import java.io.IOException;
 import java.nio.file.*;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -41,6 +42,7 @@ public class FileWatcher implements Runnable {
     private Thread watchThread;
     private Future<?> watchUpdateTask;
     private WatchService watchService;
+    private volatile Duration saveDebounce = Duration.ofSeconds(5);
 
     private final Executor taskExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
@@ -63,6 +65,8 @@ public class FileWatcher implements Runnable {
             watchThread.interrupt();
             watchService.close();
         }
+
+        saveDebounce = configLoader.load().daemon().saveDebounce();
 
         Path path = repositoryPathProvider.repositoryDirectory().toAbsolutePath();
         watchService = path.getFileSystem().newWatchService();
@@ -158,7 +162,7 @@ public class FileWatcher implements Runnable {
     private void initFileUpdate() {
         watchUpdateTask = CompletableFuture.runAsync(() -> {
             try {
-                Thread.sleep(configLoader.load().daemon().saveDebounce().toMillis());
+                Thread.sleep(saveDebounce.toMillis());
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/de/zorro909/codecheck/daemon/FileWatcher.java
+++ b/src/main/java/de/zorro909/codecheck/daemon/FileWatcher.java
@@ -2,6 +2,7 @@ package de.zorro909.codecheck.daemon;
 
 import de.zorro909.codecheck.RepositoryPathProvider;
 import de.zorro909.codecheck.RequiresCliOption;
+import de.zorro909.codecheck.config.CodeCheckConfigLoader;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
@@ -30,10 +31,10 @@ public class FileWatcher implements Runnable {
     private static final String GIT_DIRECTORY = ".git";
     private static final String TARGET_DIRECTORY = "target/";
     private static final String FILE_CHANGE_INDICATOR = "~";
-    private static final long SLEEP_DURATION_MS = 5000L;
 
     private final DaemonServer daemonServer;
     private final RepositoryPathProvider repositoryPathProvider;
+    private final CodeCheckConfigLoader configLoader;
     private final Map<WatchKey, Path> watchKeys = new HashMap<>();
     private final CopyOnWriteArrayList<Path> filesToUpdate = new CopyOnWriteArrayList<>();
 
@@ -43,9 +44,12 @@ public class FileWatcher implements Runnable {
 
     private final Executor taskExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
-    public FileWatcher(DaemonServer daemonServer, RepositoryPathProvider repositoryPathProvider) {
+    public FileWatcher(DaemonServer daemonServer,
+                       RepositoryPathProvider repositoryPathProvider,
+                       CodeCheckConfigLoader configLoader) {
         this.daemonServer = daemonServer;
         this.repositoryPathProvider = repositoryPathProvider;
+        this.configLoader = configLoader;
     }
 
 
@@ -154,7 +158,7 @@ public class FileWatcher implements Runnable {
     private void initFileUpdate() {
         watchUpdateTask = CompletableFuture.runAsync(() -> {
             try {
-                Thread.sleep(SLEEP_DURATION_MS);
+                Thread.sleep(configLoader.load().daemon().saveDebounce().toMillis());
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/de/zorro909/codecheck/watcher/ConfigChangeRestartSignal.java
+++ b/src/main/java/de/zorro909/codecheck/watcher/ConfigChangeRestartSignal.java
@@ -1,0 +1,24 @@
+package de.zorro909.codecheck.watcher;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+public class ConfigChangeRestartSignal {
+
+    private final Set<Path> configPaths;
+
+    public ConfigChangeRestartSignal(Set<Path> configPaths) {
+        this.configPaths = configPaths.stream().map(this::normalize).collect(java.util.stream.Collectors.toSet());
+    }
+
+    public void handleChange(Path path) {
+        Path normalized = normalize(path);
+        if (configPaths.contains(normalized)) {
+            throw new DaemonRestartRequiredException(normalized);
+        }
+    }
+
+    private Path normalize(Path path) {
+        return path.toAbsolutePath().normalize();
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/watcher/DaemonRestartRequiredException.java
+++ b/src/main/java/de/zorro909/codecheck/watcher/DaemonRestartRequiredException.java
@@ -1,0 +1,10 @@
+package de.zorro909.codecheck.watcher;
+
+import java.nio.file.Path;
+
+public class DaemonRestartRequiredException extends RuntimeException {
+
+    public DaemonRestartRequiredException(Path configPath) {
+        super("Configuration changed; daemon restart required: " + configPath);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/watcher/DebouncedFileUpdateScheduler.java
+++ b/src/main/java/de/zorro909/codecheck/watcher/DebouncedFileUpdateScheduler.java
@@ -1,0 +1,36 @@
+package de.zorro909.codecheck.watcher;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DebouncedFileUpdateScheduler {
+
+    private final Duration debounce;
+    private final Map<Path, Instant> pending = new LinkedHashMap<>();
+
+    public DebouncedFileUpdateScheduler(Duration debounce) {
+        this.debounce = debounce;
+    }
+
+    public synchronized void recordSave(Path path, Instant savedAt) {
+        pending.put(path.toAbsolutePath().normalize(), savedAt);
+    }
+
+    public synchronized List<Path> duePaths(Instant now) {
+        List<Path> due = pending.entrySet()
+                                .stream()
+                                .filter(entry -> !entry.getValue().plus(debounce).isAfter(now))
+                                .map(Map.Entry::getKey)
+                                .toList();
+        due.forEach(pending::remove);
+        return due;
+    }
+
+    public synchronized List<Path> pendingPaths() {
+        return List.copyOf(pending.keySet());
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/watcher/DependencyInvalidationGraph.java
+++ b/src/main/java/de/zorro909/codecheck/watcher/DependencyInvalidationGraph.java
@@ -1,0 +1,30 @@
+package de.zorro909.codecheck.watcher;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class DependencyInvalidationGraph {
+
+    private final ConcurrentHashMap<Path, Set<Path>> dependentsByContext = new ConcurrentHashMap<>();
+
+    public void recordDependency(Path contextFile, Path dependentValidatedFile) {
+        dependentsByContext.computeIfAbsent(normalize(contextFile),
+                                            _ -> ConcurrentHashMap.newKeySet())
+                           .add(normalize(dependentValidatedFile));
+    }
+
+    public Set<Path> dependents(Path contextFile) {
+        return Set.copyOf(dependentsByContext.getOrDefault(normalize(contextFile), Set.of()));
+    }
+
+    public Set<Path> invalidate(Path contextFile, IncrementalValidationState state) {
+        Set<Path> dependents = dependents(contextFile);
+        dependents.forEach(state::markStale);
+        return dependents;
+    }
+
+    private Path normalize(Path path) {
+        return path.toAbsolutePath().normalize();
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/watcher/FileValidationStatus.java
+++ b/src/main/java/de/zorro909/codecheck/watcher/FileValidationStatus.java
@@ -1,0 +1,7 @@
+package de.zorro909.codecheck.watcher;
+
+public enum FileValidationStatus {
+    STALE,
+    CHECKING,
+    CURRENT
+}

--- a/src/main/java/de/zorro909/codecheck/watcher/IncrementalValidationState.java
+++ b/src/main/java/de/zorro909/codecheck/watcher/IncrementalValidationState.java
@@ -1,0 +1,40 @@
+package de.zorro909.codecheck.watcher;
+
+import de.zorro909.codecheck.validation.Diagnostic;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class IncrementalValidationState {
+
+    private final Map<Path, FileValidationStatus> statuses = new ConcurrentHashMap<>();
+    private final Map<Path, List<Diagnostic>> diagnostics = new ConcurrentHashMap<>();
+
+    public void markChecking(Path path) {
+        statuses.put(normalize(path), FileValidationStatus.CHECKING);
+    }
+
+    public void markStale(Path path) {
+        statuses.put(normalize(path), FileValidationStatus.STALE);
+    }
+
+    public void updateCurrent(Path path, List<Diagnostic> latestDiagnostics) {
+        Path normalized = normalize(path);
+        diagnostics.put(normalized, List.copyOf(latestDiagnostics));
+        statuses.put(normalized, FileValidationStatus.CURRENT);
+    }
+
+    public FileValidationStatus status(Path path) {
+        return statuses.getOrDefault(normalize(path), FileValidationStatus.STALE);
+    }
+
+    public List<Diagnostic> diagnostics(Path path) {
+        return diagnostics.getOrDefault(normalize(path), List.of());
+    }
+
+    private Path normalize(Path path) {
+        return path.toAbsolutePath().normalize();
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/watcher/WatchPathKind.java
+++ b/src/main/java/de/zorro909/codecheck/watcher/WatchPathKind.java
@@ -1,0 +1,8 @@
+package de.zorro909.codecheck.watcher;
+
+public enum WatchPathKind {
+    VALIDATED,
+    CONTEXT,
+    PROJECT_MODEL,
+    CONFIG
+}

--- a/src/main/java/de/zorro909/codecheck/watcher/WatchScope.java
+++ b/src/main/java/de/zorro909/codecheck/watcher/WatchScope.java
@@ -1,0 +1,18 @@
+package de.zorro909.codecheck.watcher;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+public record WatchScope(Set<WatchedPath> paths) {
+
+    public WatchScope {
+        paths = Set.copyOf(paths);
+    }
+
+    public boolean contains(Path path, WatchPathKind kind) {
+        Path normalized = path.toAbsolutePath().normalize();
+        return paths.stream()
+                    .anyMatch(watchedPath -> watchedPath.path().equals(normalized)
+                                             && watchedPath.kind() == kind);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/watcher/WatchScopeService.java
+++ b/src/main/java/de/zorro909/codecheck/watcher/WatchScopeService.java
@@ -1,10 +1,13 @@
 package de.zorro909.codecheck.watcher;
 
+import de.zorro909.codecheck.RepositoryPathProvider;
 import de.zorro909.codecheck.java.MavenModule;
 import de.zorro909.codecheck.java.ProjectModel;
 import de.zorro909.codecheck.java.ProjectModelService;
 import de.zorro909.codecheck.validation.FileInterest;
 import de.zorro909.codecheck.validation.RuleRegistry;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 import java.nio.file.Path;
@@ -18,9 +21,11 @@ public class WatchScopeService {
     private final RuleRegistry ruleRegistry;
     private final ProjectModelService projectModelService;
 
-    public WatchScopeService(Path repositoryRoot,
-                             RuleRegistry ruleRegistry,
-                             ProjectModelService projectModelService) {
+    @Inject
+    public WatchScopeService(
+            @Named(RepositoryPathProvider.REPOSITORY_DIRECTORY) Path repositoryRoot,
+            RuleRegistry ruleRegistry,
+            ProjectModelService projectModelService) {
         this.repositoryRoot = repositoryRoot.toAbsolutePath().normalize();
         this.ruleRegistry = ruleRegistry;
         this.projectModelService = projectModelService;

--- a/src/main/java/de/zorro909/codecheck/watcher/WatchScopeService.java
+++ b/src/main/java/de/zorro909/codecheck/watcher/WatchScopeService.java
@@ -1,0 +1,84 @@
+package de.zorro909.codecheck.watcher;
+
+import de.zorro909.codecheck.java.MavenModule;
+import de.zorro909.codecheck.java.ProjectModel;
+import de.zorro909.codecheck.java.ProjectModelService;
+import de.zorro909.codecheck.validation.FileInterest;
+import de.zorro909.codecheck.validation.RuleRegistry;
+import jakarta.inject.Singleton;
+
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Singleton
+public class WatchScopeService {
+
+    private final Path repositoryRoot;
+    private final RuleRegistry ruleRegistry;
+    private final ProjectModelService projectModelService;
+
+    public WatchScopeService(Path repositoryRoot,
+                             RuleRegistry ruleRegistry,
+                             ProjectModelService projectModelService) {
+        this.repositoryRoot = repositoryRoot.toAbsolutePath().normalize();
+        this.ruleRegistry = ruleRegistry;
+        this.projectModelService = projectModelService;
+    }
+
+    public WatchScope watchScope() {
+        Set<WatchedPath> watchedPaths = new LinkedHashSet<>();
+        ProjectModel model = projectModelService.currentModel();
+        for (MavenModule module : model.modules()) {
+            addProjectFiles(watchedPaths, module);
+            addRuleInterests(watchedPaths, module);
+            module.generatedSourceRoots()
+                  .forEach(root -> watchedPaths.add(new WatchedPath(root, WatchPathKind.CONTEXT,
+                                                                    "generated source context")));
+            module.generatedTestSourceRoots()
+                  .forEach(root -> watchedPaths.add(new WatchedPath(root, WatchPathKind.CONTEXT,
+                                                                    "generated test context")));
+        }
+        watchedPaths.add(new WatchedPath(userConfigPath(), WatchPathKind.CONFIG, "user config"));
+        watchedPaths.add(new WatchedPath(repositoryRoot.resolve(".codecheck.yaml"),
+                                         WatchPathKind.CONFIG, "repo config"));
+        return new WatchScope(watchedPaths);
+    }
+
+    private void addProjectFiles(Set<WatchedPath> watchedPaths, MavenModule module) {
+        watchedPaths.add(new WatchedPath(module.moduleRoot().resolve("pom.xml"),
+                                         WatchPathKind.PROJECT_MODEL, "Maven project model"));
+    }
+
+    private void addRuleInterests(Set<WatchedPath> watchedPaths, MavenModule module) {
+        for (FileInterest interest : ruleRegistry.watchPlan().validatedFiles()) {
+            if (interest.matches(module.moduleRoot().resolve("src/main/java/Example.java"))) {
+                module.sourceRoots()
+                      .forEach(root -> watchedPaths.add(new WatchedPath(root,
+                                                                        WatchPathKind.VALIDATED,
+                                                                        interest.description())));
+            }
+            if (interest.matches(module.moduleRoot().resolve("src/test/java/ExampleTest.java"))) {
+                module.testRoots()
+                      .forEach(root -> watchedPaths.add(new WatchedPath(root,
+                                                                        WatchPathKind.VALIDATED,
+                                                                        interest.description())));
+            }
+            if (interest.includeGlobs().contains("pom.xml")) {
+                watchedPaths.add(new WatchedPath(module.moduleRoot().resolve("pom.xml"),
+                                                 WatchPathKind.PROJECT_MODEL,
+                                                 interest.description()));
+            }
+        }
+        for (FileInterest interest : ruleRegistry.watchPlan().contextFiles()) {
+            module.contextRoots()
+                  .forEach(root -> watchedPaths.add(new WatchedPath(root, WatchPathKind.CONTEXT,
+                                                                    interest.description())));
+        }
+    }
+
+    private Path userConfigPath() {
+        return Path.of(System.getProperty("user.home"), ".config", "git-commit-code-check",
+                       "config.yaml");
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/watcher/WatchedPath.java
+++ b/src/main/java/de/zorro909/codecheck/watcher/WatchedPath.java
@@ -1,0 +1,12 @@
+package de.zorro909.codecheck.watcher;
+
+import java.nio.file.Path;
+
+public record WatchedPath(Path path,
+                          WatchPathKind kind,
+                          String reason) {
+
+    public WatchedPath {
+        path = path.toAbsolutePath().normalize();
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/daemon/FileWatcherConfigTest.java
+++ b/src/test/java/de/zorro909/codecheck/daemon/FileWatcherConfigTest.java
@@ -1,0 +1,70 @@
+package de.zorro909.codecheck.daemon;
+
+import de.zorro909.codecheck.RepositoryPathProvider;
+import de.zorro909.codecheck.ValidationCheckPipeline;
+import de.zorro909.codecheck.config.CodeCheckConfig;
+import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import de.zorro909.codecheck.config.ConfigOverrides;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileWatcherConfigTest {
+
+    @Test
+    void watchResolvesSaveDebounceFromConfigOnce(@TempDir Path tempDir) throws Exception {
+        AtomicInteger loadCount = new AtomicInteger();
+        CodeCheckConfigLoader countingLoader = new CodeCheckConfigLoader() {
+            @Override
+            public CodeCheckConfig load() {
+                loadCount.incrementAndGet();
+                return CodeCheckConfig.defaults();
+            }
+
+            @Override
+            public CodeCheckConfig load(ConfigOverrides overrides) {
+                return load();
+            }
+        };
+        FileWatcher watcher = new FileWatcher(daemonServer(),
+                                              repositoryPathProvider(tempDir),
+                                              countingLoader);
+
+        watcher.watch();
+
+        assertThat(loadCount).hasValue(1);
+    }
+
+    private RepositoryPathProvider repositoryPathProvider(Path directory) {
+        return new RepositoryPathProvider() {
+            @Override
+            public Path repositoryDirectory() {
+                return directory;
+            }
+        };
+    }
+
+    private DaemonServer daemonServer() {
+        return new DaemonServer(Stream::empty, () -> {
+            ValidationCheckPipeline pipeline = new ValidationCheckPipeline();
+            setField(pipeline, "codeChecker", List.of());
+            return pipeline;
+        });
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set field: " + fieldName, e);
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/watcher/ConfigChangeRestartSignalTest.java
+++ b/src/test/java/de/zorro909/codecheck/watcher/ConfigChangeRestartSignalTest.java
@@ -1,0 +1,30 @@
+package de.zorro909.codecheck.watcher;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConfigChangeRestartSignalTest {
+
+    @Test
+    void configChangeRaisesRestartRequired() {
+        Path config = Path.of(".codecheck.yaml");
+        ConfigChangeRestartSignal signal = new ConfigChangeRestartSignal(Set.of(config));
+
+        assertThatThrownBy(() -> signal.handleChange(config))
+                .isInstanceOf(DaemonRestartRequiredException.class)
+                .hasMessageContaining("daemon restart required");
+    }
+
+    @Test
+    void nonConfigChangeDoesNotRaiseRestartRequired() {
+        ConfigChangeRestartSignal signal = new ConfigChangeRestartSignal(Set.of(Path.of(".codecheck.yaml")));
+
+        assertThatCode(() -> signal.handleChange(Path.of("src/main/java/Example.java")))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/watcher/DebouncedFileUpdateSchedulerTest.java
+++ b/src/test/java/de/zorro909/codecheck/watcher/DebouncedFileUpdateSchedulerTest.java
@@ -1,0 +1,28 @@
+package de.zorro909.codecheck.watcher;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DebouncedFileUpdateSchedulerTest {
+
+    @Test
+    void saveIsReleasedOnlyAfterConfiguredDebounce() {
+        DebouncedFileUpdateScheduler scheduler = new DebouncedFileUpdateScheduler(
+                Duration.ofSeconds(5));
+        Instant savedAt = Instant.parse("2026-07-07T00:00:00Z");
+        Path file = Path.of("src/main/java/Example.java");
+
+        scheduler.recordSave(file, savedAt);
+
+        assertThat(scheduler.duePaths(savedAt.plusSeconds(4))).isEmpty();
+        assertThat(scheduler.pendingPaths()).hasSize(1);
+        assertThat(scheduler.duePaths(savedAt.plusSeconds(5))).containsExactly(
+                file.toAbsolutePath().normalize());
+        assertThat(scheduler.pendingPaths()).isEmpty();
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/watcher/IncrementalStateAndInvalidationTest.java
+++ b/src/test/java/de/zorro909/codecheck/watcher/IncrementalStateAndInvalidationTest.java
@@ -1,0 +1,49 @@
+package de.zorro909.codecheck.watcher;
+
+import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.validation.Diagnostic;
+import de.zorro909.codecheck.validation.DiagnosticKind;
+import de.zorro909.codecheck.validation.RuleId;
+import de.zorro909.codecheck.validation.SourcePosition;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IncrementalStateAndInvalidationTest {
+
+    @Test
+    void storesLatestStateOnlyByFile() {
+        IncrementalValidationState state = new IncrementalValidationState();
+        Path file = Path.of("src/main/java/Example.java");
+        Diagnostic first = diagnostic(file, "first");
+        Diagnostic second = diagnostic(file, "second");
+
+        state.updateCurrent(file, List.of(first));
+        state.updateCurrent(file, List.of(second));
+
+        assertThat(state.status(file)).isEqualTo(FileValidationStatus.CURRENT);
+        assertThat(state.diagnostics(file)).containsExactly(second);
+    }
+
+    @Test
+    void contextChangeInvalidatesDependentValidatedFiles() {
+        IncrementalValidationState state = new IncrementalValidationState();
+        DependencyInvalidationGraph graph = new DependencyInvalidationGraph();
+        Path generated = Path.of("target/generated-sources/annotations/MapperImpl.java");
+        Path mapper = Path.of("src/main/java/Mapper.java");
+        state.updateCurrent(mapper, List.of());
+        graph.recordDependency(generated, mapper);
+
+        assertThat(graph.invalidate(generated, state)).containsExactly(mapper.toAbsolutePath().normalize());
+        assertThat(state.status(mapper)).isEqualTo(FileValidationStatus.STALE);
+    }
+
+    private Diagnostic diagnostic(Path file, String message) {
+        return new Diagnostic(file, message, new SourcePosition(1, 1),
+                              ValidationError.Severity.LOW, DiagnosticKind.RULE_VIOLATION,
+                              new RuleId("test"));
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/watcher/WatchScopeServiceBeanTest.java
+++ b/src/test/java/de/zorro909/codecheck/watcher/WatchScopeServiceBeanTest.java
@@ -1,0 +1,20 @@
+package de.zorro909.codecheck.watcher;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WatchScopeServiceBeanTest {
+
+    @Test
+    void watchScopeServiceBeanResolvesWithRepositoryDirectory() {
+        try (ApplicationContext context = ApplicationContext.builder()
+                                                            .singletons((Object) new String[0])
+                                                            .start()) {
+            WatchScopeService service = context.getBean(WatchScopeService.class);
+
+            assertThat(service.watchScope().paths()).isNotEmpty();
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/watcher/WatchScopeServiceTest.java
+++ b/src/test/java/de/zorro909/codecheck/watcher/WatchScopeServiceTest.java
@@ -1,0 +1,113 @@
+package de.zorro909.codecheck.watcher;
+
+import de.zorro909.codecheck.java.MavenModule;
+import de.zorro909.codecheck.java.ModuleId;
+import de.zorro909.codecheck.java.ProjectModel;
+import de.zorro909.codecheck.java.ProjectModelService;
+import de.zorro909.codecheck.validation.FileInterest;
+import de.zorro909.codecheck.validation.Fixer;
+import de.zorro909.codecheck.validation.Rule;
+import de.zorro909.codecheck.validation.RuleRegistry;
+import de.zorro909.codecheck.validation.WatchPlan;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WatchScopeServiceTest {
+
+    @Test
+    void javaRuleInterestAddsModuleJavaRoots(@TempDir Path repo) {
+        WatchScopeService service = new WatchScopeService(repo, registry(
+                List.of(FileInterest.javaMainSources()), List.of()), projectModel(repo));
+
+        WatchScope scope = service.watchScope();
+
+        assertThat(scope.contains(repo.resolve("module-a/src/main/java"),
+                                  WatchPathKind.VALIDATED)).isTrue();
+        assertThat(scope.contains(repo.resolve("module-a/target/generated-sources/annotations"),
+                                  WatchPathKind.VALIDATED)).isFalse();
+    }
+
+    @Test
+    void pomInterestAddsPomFilesToProjectModelWatchScope(@TempDir Path repo) {
+        FileInterest pomInterest = new FileInterest("POM rule", List.of("pom.xml"),
+                                                    path -> path.getFileName()
+                                                                .toString()
+                                                                .equals("pom.xml"));
+        WatchScopeService service = new WatchScopeService(repo, registry(List.of(pomInterest),
+                                                                         List.of()),
+                                                          projectModel(repo));
+
+        WatchScope scope = service.watchScope();
+
+        assertThat(scope.contains(repo.resolve("module-a/pom.xml"), WatchPathKind.PROJECT_MODEL))
+                .isTrue();
+    }
+
+    @Test
+    void generatedRootsAreContextOnly(@TempDir Path repo) {
+        WatchScopeService service = new WatchScopeService(repo, registry(List.of(), List.of()),
+                                                          projectModel(repo));
+
+        WatchScope scope = service.watchScope();
+
+        Path generated = repo.resolve("module-a/target/generated-sources/annotations");
+        assertThat(scope.contains(generated, WatchPathKind.CONTEXT)).isTrue();
+        assertThat(scope.contains(generated, WatchPathKind.VALIDATED)).isFalse();
+    }
+
+    @Test
+    void configFilesAreWatched(@TempDir Path repo) {
+        WatchScopeService service = new WatchScopeService(repo, registry(List.of(), List.of()),
+                                                          projectModel(repo));
+
+        WatchScope scope = service.watchScope();
+
+        assertThat(scope.contains(repo.resolve(".codecheck.yaml"), WatchPathKind.CONFIG)).isTrue();
+    }
+
+    private RuleRegistry registry(List<FileInterest> validated, List<FileInterest> context) {
+        return new RuleRegistry() {
+            @Override
+            public List<Rule> activeRules() {
+                return List.of();
+            }
+
+            @Override
+            public List<Fixer> activeFixers() {
+                return List.of();
+            }
+
+            @Override
+            public WatchPlan watchPlan() {
+                return new WatchPlan(validated, context);
+            }
+        };
+    }
+
+    private ProjectModelService projectModel(Path repo) {
+        MavenModule module = new MavenModule(new ModuleId("module-a"), repo.resolve("module-a"),
+                                             List.of(repo.resolve("module-a/src/main/java")),
+                                             List.of(repo.resolve("module-a/src/test/java")),
+                                             List.of(repo.resolve(
+                                                     "module-a/target/generated-sources/annotations")),
+                                             List.of(repo.resolve(
+                                                     "module-a/target/generated-test-sources/test-annotations")));
+        ProjectModel model = new ProjectModel(repo, repo, List.of(module), 25);
+        return new ProjectModelService() {
+            @Override
+            public ProjectModel currentModel() {
+                return model;
+            }
+
+            @Override
+            public ProjectModel refresh() {
+                return model;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add the CR-007 implementation specification
- introduce rule-driven watch scope planning from rule interests and Maven project model roots
- add configurable debounce primitives, latest validation state, and context-to-dependent invalidation graph
- add config-change restart signaling
- wire FileWatcher debounce delay to typed configuration

## Tests
- ./mvnw test