### PR TITLE
CR-008: Docker mvnd test runner

### DIFF
--- a/docs/implementation-specs/CR-008-docker-mvnd-test-runner.md
+++ b/docs/implementation-specs/CR-008-docker-mvnd-test-runner.md
@@ -1,0 +1,51 @@
+# CR-008 Implementation Specification: Docker mvnd Test Runner
+
+## Scope
+
+This increment introduces a daemon-owned `TestRunner` abstraction and a Docker/mvnd implementation.
+The Docker process execution is isolated behind `DockerCommandExecutor` so lifecycle and command
+behavior are testable without requiring Docker in unit tests.
+
+## Runner API
+
+- `TestRunner.runTests(TestRunRequest request)`
+- `TestRunner.stop()`
+- `TestRunRequest` supports modules, specific test classes, retry-failing-tests flag, full-run flag,
+  coverage report generation, and additional Maven args.
+- `TestRunResult` returns success, exit code, stdout, stderr, container id, and the exact Maven
+  command used.
+
+## Docker mvnd Lifecycle
+
+`DockerMvndTestRunner`:
+
+- starts a Docker container on demand
+- reuses the warm container for subsequent runs
+- stops the container after configured idle timeout
+- restarts the container if the executor reports it is no longer running
+- runs Maven commands from the repository root
+
+## Command Shape
+
+Module-specific targeted tests produce:
+
+```text
+mvnd -pl <module> <args> <targetedTestProperty>=<tests> <goals>
+```
+
+Defaults come from typed config:
+
+- image: `maven.docker.image`
+- idle timeout: `maven.docker.containerIdleTimeout`
+- goals: `maven.goals`
+- args: `maven.args`
+- targeted property: `maven.targetedTestProperty`
+- prefer mvnd: `maven.preferMvnd`
+
+## Tests
+
+- The runner starts a Docker container on demand.
+- A second run within the idle timeout reuses the warm container.
+- Targeted test execution passes the configured targeted test property.
+- Module-specific execution passes `-pl`.
+- Idle reaping stops the container after configured inactivity.

--- a/src/main/java/de/zorro909/codecheck/runner/CommandResult.java
+++ b/src/main/java/de/zorro909/codecheck/runner/CommandResult.java
@@ -1,0 +1,10 @@
+package de.zorro909.codecheck.runner;
+
+public record CommandResult(int exitCode,
+                            String stdout,
+                            String stderr) {
+
+    public boolean success() {
+        return exitCode == 0;
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/runner/DockerCommandExecutor.java
+++ b/src/main/java/de/zorro909/codecheck/runner/DockerCommandExecutor.java
@@ -1,0 +1,15 @@
+package de.zorro909.codecheck.runner;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public interface DockerCommandExecutor {
+
+    String startContainer(String image, Path repositoryRoot, boolean mountM2);
+
+    boolean isRunning(String containerId);
+
+    CommandResult exec(String containerId, Path workingDirectory, List<String> command);
+
+    void stopContainer(String containerId);
+}

--- a/src/main/java/de/zorro909/codecheck/runner/DockerCommandExecutor.java
+++ b/src/main/java/de/zorro909/codecheck/runner/DockerCommandExecutor.java
@@ -12,4 +12,6 @@ public interface DockerCommandExecutor {
     CommandResult exec(String containerId, Path workingDirectory, List<String> command);
 
     void stopContainer(String containerId);
+
+    void removeContainersForRepository(Path repositoryRoot);
 }

--- a/src/main/java/de/zorro909/codecheck/runner/DockerMvndTestRunner.java
+++ b/src/main/java/de/zorro909/codecheck/runner/DockerMvndTestRunner.java
@@ -1,0 +1,99 @@
+package de.zorro909.codecheck.runner;
+
+import de.zorro909.codecheck.config.CodeCheckConfig;
+import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import jakarta.inject.Singleton;
+
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class DockerMvndTestRunner implements TestRunner {
+
+    private final Path repositoryRoot;
+    private final CodeCheckConfigLoader configLoader;
+    private final DockerCommandExecutor docker;
+    private final Clock clock;
+    private String containerId;
+    private Instant lastUsed;
+
+    public DockerMvndTestRunner(Path repositoryRoot,
+                                CodeCheckConfigLoader configLoader,
+                                DockerCommandExecutor docker) {
+        this(repositoryRoot, configLoader, docker, Clock.systemUTC());
+    }
+
+    DockerMvndTestRunner(Path repositoryRoot,
+                         CodeCheckConfigLoader configLoader,
+                         DockerCommandExecutor docker,
+                         Clock clock) {
+        this.repositoryRoot = repositoryRoot.toAbsolutePath().normalize();
+        this.configLoader = configLoader;
+        this.docker = docker;
+        this.clock = clock;
+    }
+
+    @Override
+    public synchronized TestRunResult runTests(TestRunRequest request) {
+        CodeCheckConfig.Maven config = configLoader.load().maven();
+        String activeContainer = ensureContainer(config);
+        List<String> command = mavenCommand(config, request);
+        CommandResult result = docker.exec(activeContainer, repositoryRoot, command);
+        lastUsed = clock.instant();
+        return new TestRunResult(result.success(), result.exitCode(), result.stdout(),
+                                 result.stderr(), activeContainer, command);
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (containerId != null) {
+            docker.stopContainer(containerId);
+            containerId = null;
+            lastUsed = null;
+        }
+    }
+
+    public synchronized void reapIdleContainer() {
+        if (containerId == null || lastUsed == null) {
+            return;
+        }
+        if (lastUsed.plus(configLoader.load().maven().docker().containerIdleTimeout())
+                    .isBefore(clock.instant())
+            || lastUsed.plus(configLoader.load().maven().docker().containerIdleTimeout())
+                       .equals(clock.instant())) {
+            stop();
+        }
+    }
+
+    private String ensureContainer(CodeCheckConfig.Maven config) {
+        if (containerId == null || !docker.isRunning(containerId)) {
+            containerId = docker.startContainer(config.docker().image(), repositoryRoot,
+                                                config.docker().mountM2());
+        }
+        lastUsed = clock.instant();
+        return containerId;
+    }
+
+    private List<String> mavenCommand(CodeCheckConfig.Maven config, TestRunRequest request) {
+        List<String> command = new ArrayList<>();
+        command.add(config.preferMvnd() ? "mvnd" : "mvn");
+        if (!request.modules().isEmpty()) {
+            command.add("-pl");
+            command.add(String.join(",", request.modules()));
+        }
+        command.addAll(config.args());
+        command.addAll(request.additionalMavenArgs());
+        if (!request.testClasses().isEmpty()) {
+            command.add(config.targetedTestProperty() + "="
+                        + String.join(",", request.testClasses()));
+        }
+        command.addAll(config.goals());
+        if (!request.generateCoverageReport()) {
+            command.removeIf(goal -> goal.toLowerCase(java.util.Locale.ROOT).contains("jacoco"));
+        }
+        return command;
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/runner/DockerMvndTestRunner.java
+++ b/src/main/java/de/zorro909/codecheck/runner/DockerMvndTestRunner.java
@@ -1,7 +1,10 @@
 package de.zorro909.codecheck.runner;
 
+import de.zorro909.codecheck.RepositoryPathProvider;
 import de.zorro909.codecheck.config.CodeCheckConfig;
 import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 import java.nio.file.Path;
@@ -20,9 +23,11 @@ public class DockerMvndTestRunner implements TestRunner {
     private String containerId;
     private Instant lastUsed;
 
-    public DockerMvndTestRunner(Path repositoryRoot,
-                                CodeCheckConfigLoader configLoader,
-                                DockerCommandExecutor docker) {
+    @Inject
+    public DockerMvndTestRunner(
+            @Named(RepositoryPathProvider.REPOSITORY_DIRECTORY) Path repositoryRoot,
+            CodeCheckConfigLoader configLoader,
+            DockerCommandExecutor docker) {
         this(repositoryRoot, configLoader, docker, Clock.systemUTC());
     }
 
@@ -70,6 +75,7 @@ public class DockerMvndTestRunner implements TestRunner {
 
     private String ensureContainer(CodeCheckConfig.Maven config) {
         if (containerId == null || !docker.isRunning(containerId)) {
+            docker.removeContainersForRepository(repositoryRoot);
             containerId = docker.startContainer(config.docker().image(), repositoryRoot,
                                                 config.docker().mountM2());
         }

--- a/src/main/java/de/zorro909/codecheck/runner/ProcessDockerCommandExecutor.java
+++ b/src/main/java/de/zorro909/codecheck/runner/ProcessDockerCommandExecutor.java
@@ -1,0 +1,72 @@
+package de.zorro909.codecheck.runner;
+
+import jakarta.inject.Singleton;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class ProcessDockerCommandExecutor implements DockerCommandExecutor {
+
+    @Override
+    public String startContainer(String image, Path repositoryRoot, boolean mountM2) {
+        List<String> command = new ArrayList<>(List.of("docker", "run", "-d", "-w", "/workspace",
+                                                       "-v", repositoryRoot.toAbsolutePath()
+                                                                            + ":/workspace"));
+        if (mountM2) {
+            command.add("-v");
+            command.add(Path.of(System.getProperty("user.home"), ".m2").toAbsolutePath()
+                        + ":/root/.m2");
+        }
+        command.add(image);
+        command.add("sleep");
+        command.add("infinity");
+        CommandResult result = run(command);
+        if (!result.success()) {
+            throw new IllegalStateException("Failed to start Docker test container: "
+                                            + result.stderr());
+        }
+        return result.stdout().strip();
+    }
+
+    @Override
+    public boolean isRunning(String containerId) {
+        return run(List.of("docker", "inspect", "-f", "{{.State.Running}}", containerId))
+                .stdout()
+                .strip()
+                .equals("true");
+    }
+
+    @Override
+    public CommandResult exec(String containerId, Path workingDirectory, List<String> command) {
+        List<String> dockerCommand = new ArrayList<>(List.of("docker", "exec", "-w",
+                                                             "/workspace", containerId));
+        dockerCommand.addAll(command);
+        return run(dockerCommand);
+    }
+
+    @Override
+    public void stopContainer(String containerId) {
+        run(List.of("docker", "rm", "-f", containerId));
+    }
+
+    private CommandResult run(List<String> command) {
+        try {
+            Process process = new ProcessBuilder(command).start();
+            String stdout = new String(process.getInputStream().readAllBytes(),
+                                       StandardCharsets.UTF_8);
+            String stderr = new String(process.getErrorStream().readAllBytes(),
+                                       StandardCharsets.UTF_8);
+            return new CommandResult(process.waitFor(), stdout, stderr);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to execute " + String.join(" ", command), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while executing "
+                                            + String.join(" ", command), e);
+        }
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/runner/ProcessDockerCommandExecutor.java
+++ b/src/main/java/de/zorro909/codecheck/runner/ProcessDockerCommandExecutor.java
@@ -7,13 +7,17 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Singleton
 public class ProcessDockerCommandExecutor implements DockerCommandExecutor {
 
+    static final String REPOSITORY_LABEL = "de.zorro909.git-commit-code-check.repo";
+
     @Override
     public String startContainer(String image, Path repositoryRoot, boolean mountM2) {
         List<String> command = new ArrayList<>(List.of("docker", "run", "-d", "-w", "/workspace",
+                                                       "--label", repositoryLabel(repositoryRoot),
                                                        "-v", repositoryRoot.toAbsolutePath()
                                                                             + ":/workspace"));
         if (mountM2) {
@@ -53,13 +57,36 @@ public class ProcessDockerCommandExecutor implements DockerCommandExecutor {
         run(List.of("docker", "rm", "-f", containerId));
     }
 
-    private CommandResult run(List<String> command) {
+    @Override
+    public void removeContainersForRepository(Path repositoryRoot) {
+        CommandResult listing = run(List.of("docker", "ps", "-aq", "--filter",
+                                            "label=" + repositoryLabel(repositoryRoot)));
+        listing.stdout()
+               .lines()
+               .map(String::strip)
+               .filter(line -> !line.isEmpty())
+               .forEach(this::stopContainer);
+    }
+
+    private String repositoryLabel(Path repositoryRoot) {
+        return REPOSITORY_LABEL + "=" + repositoryRoot.toAbsolutePath().normalize();
+    }
+
+    CommandResult run(List<String> command) {
         try {
             Process process = new ProcessBuilder(command).start();
+            AtomicReference<byte[]> stderrBytes = new AtomicReference<>(new byte[0]);
+            Thread stderrReader = Thread.ofVirtual().start(() -> {
+                try {
+                    stderrBytes.set(process.getErrorStream().readAllBytes());
+                } catch (IOException ignored) {
+                    // The process ended without a readable stderr stream.
+                }
+            });
             String stdout = new String(process.getInputStream().readAllBytes(),
                                        StandardCharsets.UTF_8);
-            String stderr = new String(process.getErrorStream().readAllBytes(),
-                                       StandardCharsets.UTF_8);
+            stderrReader.join();
+            String stderr = new String(stderrBytes.get(), StandardCharsets.UTF_8);
             return new CommandResult(process.waitFor(), stdout, stderr);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to execute " + String.join(" ", command), e);

--- a/src/main/java/de/zorro909/codecheck/runner/TestRunRequest.java
+++ b/src/main/java/de/zorro909/codecheck/runner/TestRunRequest.java
@@ -1,0 +1,25 @@
+package de.zorro909.codecheck.runner;
+
+import java.util.List;
+
+public record TestRunRequest(List<String> modules,
+                             List<String> testClasses,
+                             boolean retryFailingTests,
+                             boolean fullRun,
+                             boolean generateCoverageReport,
+                             List<String> additionalMavenArgs) {
+
+    public TestRunRequest {
+        modules = List.copyOf(modules);
+        testClasses = List.copyOf(testClasses);
+        additionalMavenArgs = List.copyOf(additionalMavenArgs);
+    }
+
+    public static TestRunRequest full() {
+        return new TestRunRequest(List.of(), List.of(), false, true, true, List.of());
+    }
+
+    public static TestRunRequest targeted(List<String> modules, List<String> testClasses) {
+        return new TestRunRequest(modules, testClasses, false, false, true, List.of());
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/runner/TestRunResult.java
+++ b/src/main/java/de/zorro909/codecheck/runner/TestRunResult.java
@@ -1,0 +1,15 @@
+package de.zorro909.codecheck.runner;
+
+import java.util.List;
+
+public record TestRunResult(boolean success,
+                            int exitCode,
+                            String stdout,
+                            String stderr,
+                            String containerId,
+                            List<String> mavenCommand) {
+
+    public TestRunResult {
+        mavenCommand = List.copyOf(mavenCommand);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/runner/TestRunner.java
+++ b/src/main/java/de/zorro909/codecheck/runner/TestRunner.java
@@ -1,0 +1,8 @@
+package de.zorro909.codecheck.runner;
+
+public interface TestRunner {
+
+    TestRunResult runTests(TestRunRequest request);
+
+    void stop();
+}

--- a/src/test/java/de/zorro909/codecheck/runner/DockerMvndTestRunnerBeanTest.java
+++ b/src/test/java/de/zorro909/codecheck/runner/DockerMvndTestRunnerBeanTest.java
@@ -1,0 +1,18 @@
+package de.zorro909.codecheck.runner;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DockerMvndTestRunnerBeanTest {
+
+    @Test
+    void testRunnerBeanResolvesDockerImplementation() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            TestRunner runner = context.getBean(TestRunner.class);
+
+            assertThat(runner).isInstanceOf(DockerMvndTestRunner.class);
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/runner/DockerMvndTestRunnerTest.java
+++ b/src/test/java/de/zorro909/codecheck/runner/DockerMvndTestRunnerTest.java
@@ -84,6 +84,18 @@ class DockerMvndTestRunnerTest {
     }
 
     @Test
+    void staleContainersAreRemovedBeforeStartingNewContainer(@TempDir Path repo) {
+        FakeDockerExecutor docker = new FakeDockerExecutor();
+        DockerMvndTestRunner runner = runner(repo, docker, new MutableClock());
+
+        runner.runTests(TestRunRequest.full());
+
+        assertThat(docker.removedRepositories)
+                .containsExactly(repo.toAbsolutePath().normalize());
+        assertThat(docker.startedImages).hasSize(1);
+    }
+
+    @Test
     void exitedContainerIsRestartedOnNextRun(@TempDir Path repo) {
         FakeDockerExecutor docker = new FakeDockerExecutor();
         DockerMvndTestRunner runner = runner(repo, docker, new MutableClock());
@@ -119,6 +131,7 @@ class DockerMvndTestRunnerTest {
         private final List<String> startedImages = new ArrayList<>();
         private final List<List<String>> executedCommands = new ArrayList<>();
         private final List<String> stoppedContainers = new ArrayList<>();
+        private final List<Path> removedRepositories = new ArrayList<>();
         private boolean running = true;
 
         @Override
@@ -143,6 +156,11 @@ class DockerMvndTestRunnerTest {
         public void stopContainer(String containerId) {
             stoppedContainers.add(containerId);
             running = false;
+        }
+
+        @Override
+        public void removeContainersForRepository(Path repositoryRoot) {
+            removedRepositories.add(repositoryRoot);
         }
     }
 

--- a/src/test/java/de/zorro909/codecheck/runner/DockerMvndTestRunnerTest.java
+++ b/src/test/java/de/zorro909/codecheck/runner/DockerMvndTestRunnerTest.java
@@ -1,0 +1,172 @@
+package de.zorro909.codecheck.runner;
+
+import de.zorro909.codecheck.config.CodeCheckConfig;
+import de.zorro909.codecheck.config.CodeCheckConfigLoader;
+import de.zorro909.codecheck.config.ConfigOverrides;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DockerMvndTestRunnerTest {
+
+    @Test
+    void startsDockerContainerOnDemand(@TempDir Path repo) {
+        FakeDockerExecutor docker = new FakeDockerExecutor();
+        DockerMvndTestRunner runner = runner(repo, docker, new MutableClock());
+
+        TestRunResult result = runner.runTests(TestRunRequest.full());
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.containerId()).isEqualTo("container-1");
+        assertThat(docker.startedImages).containsExactly("team/mvnd-jdk25:latest");
+        assertThat(result.mavenCommand()).startsWith("mvnd");
+    }
+
+    @Test
+    void secondRunWithinIdleTimeoutReusesWarmContainer(@TempDir Path repo) {
+        FakeDockerExecutor docker = new FakeDockerExecutor();
+        MutableClock clock = new MutableClock();
+        DockerMvndTestRunner runner = runner(repo, docker, clock);
+
+        runner.runTests(TestRunRequest.full());
+        clock.advance(Duration.ofMinutes(5));
+        runner.runTests(TestRunRequest.full());
+
+        assertThat(docker.startedImages).hasSize(1);
+        assertThat(docker.executedCommands).hasSize(2);
+    }
+
+    @Test
+    void targetedModuleRunPassesTestPropertyAndModuleList(@TempDir Path repo) {
+        FakeDockerExecutor docker = new FakeDockerExecutor();
+        DockerMvndTestRunner runner = runner(repo, docker, new MutableClock());
+
+        TestRunResult result = runner.runTests(TestRunRequest.targeted(
+                List.of("service-a"), List.of("UserTest", "OrderTest")));
+
+        assertThat(result.mavenCommand()).containsSubsequence("mvnd", "-pl", "service-a");
+        assertThat(result.mavenCommand()).contains("-Dtest=UserTest,OrderTest");
+        assertThat(result.mavenCommand()).contains("test", "jacoco:report");
+    }
+
+    @Test
+    void requestAdditionalArgsAreIncludedAfterConfiguredArgs(@TempDir Path repo) {
+        FakeDockerExecutor docker = new FakeDockerExecutor();
+        DockerMvndTestRunner runner = runner(repo, docker, new MutableClock());
+
+        TestRunResult result = runner.runTests(new TestRunRequest(
+                List.of(), List.of(), false, true, false, List.of("-DskipITs")));
+
+        assertThat(result.mavenCommand()).containsSubsequence("mvnd", "-DskipITs", "test");
+        assertThat(result.mavenCommand()).doesNotContain("jacoco:report");
+    }
+
+    @Test
+    void idleContainerStopsAfterConfiguredTimeout(@TempDir Path repo) {
+        FakeDockerExecutor docker = new FakeDockerExecutor();
+        MutableClock clock = new MutableClock();
+        DockerMvndTestRunner runner = runner(repo, docker, clock);
+        runner.runTests(TestRunRequest.full());
+
+        clock.advance(Duration.ofMinutes(10));
+        runner.reapIdleContainer();
+
+        assertThat(docker.stoppedContainers).containsExactly("container-1");
+    }
+
+    @Test
+    void exitedContainerIsRestartedOnNextRun(@TempDir Path repo) {
+        FakeDockerExecutor docker = new FakeDockerExecutor();
+        DockerMvndTestRunner runner = runner(repo, docker, new MutableClock());
+        runner.runTests(TestRunRequest.full());
+        docker.running = false;
+
+        TestRunResult result = runner.runTests(TestRunRequest.full());
+
+        assertThat(result.containerId()).isEqualTo("container-2");
+        assertThat(docker.startedImages).hasSize(2);
+    }
+
+    private DockerMvndTestRunner runner(Path repo, FakeDockerExecutor docker, MutableClock clock) {
+        return new DockerMvndTestRunner(repo, configLoader(), docker, clock);
+    }
+
+    private CodeCheckConfigLoader configLoader() {
+        return new CodeCheckConfigLoader() {
+            @Override
+            public CodeCheckConfig load() {
+                return CodeCheckConfig.defaults();
+            }
+
+            @Override
+            public CodeCheckConfig load(ConfigOverrides overrides) {
+                return overrides.apply(CodeCheckConfig.defaults());
+            }
+        };
+    }
+
+    private static final class FakeDockerExecutor implements DockerCommandExecutor {
+
+        private final List<String> startedImages = new ArrayList<>();
+        private final List<List<String>> executedCommands = new ArrayList<>();
+        private final List<String> stoppedContainers = new ArrayList<>();
+        private boolean running = true;
+
+        @Override
+        public String startContainer(String image, Path repositoryRoot, boolean mountM2) {
+            startedImages.add(image);
+            running = true;
+            return "container-" + startedImages.size();
+        }
+
+        @Override
+        public boolean isRunning(String containerId) {
+            return running;
+        }
+
+        @Override
+        public CommandResult exec(String containerId, Path workingDirectory, List<String> command) {
+            executedCommands.add(List.copyOf(command));
+            return new CommandResult(0, "ok", "");
+        }
+
+        @Override
+        public void stopContainer(String containerId) {
+            stoppedContainers.add(containerId);
+            running = false;
+        }
+    }
+
+    private static final class MutableClock extends Clock {
+
+        private Instant now = Instant.parse("2026-07-07T00:00:00Z");
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.of("UTC");
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return now;
+        }
+
+        private void advance(Duration duration) {
+            now = now.plus(duration);
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/runner/ProcessDockerCommandExecutorTest.java
+++ b/src/test/java/de/zorro909/codecheck/runner/ProcessDockerCommandExecutorTest.java
@@ -1,0 +1,30 @@
+package de.zorro909.codecheck.runner;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class ProcessDockerCommandExecutorTest {
+
+    @Test
+    void largeStderrOutputDoesNotDeadlockCommandExecution() {
+        assumeTrue(!System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win"));
+        ProcessDockerCommandExecutor executor = new ProcessDockerCommandExecutor();
+
+        CommandResult result = assertTimeoutPreemptively(Duration.ofSeconds(20), () ->
+                executor.run(List.of("/bin/sh", "-c",
+                                     "i=0; while [ $i -lt 4000 ]; do"
+                                     + " echo 'stderr filler line to exceed the pipe buffer' 1>&2;"
+                                     + " i=$((i+1)); done; echo done")));
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.stdout()).contains("done");
+        assertThat(result.stderr()).contains("stderr filler line");
+    }
+}


### PR DESCRIPTION
## Summary
- add the CR-008 implementation specification
- introduce TestRunner, TestRunRequest, and TestRunResult
- add DockerCommandExecutor boundary plus process-backed Docker executor
- implement daemon-owned DockerMvndTestRunner with warm container reuse, idle reaping, targeted tests, module -pl, and configurable Maven command shape

## Tests
- ./mvnw test