### PR TITLE
CR-009: JaCoCo coverage and MapStruct

### DIFF
--- a/docs/implementation-specs/CR-009-jacoco-coverage-and-mapstruct.md
+++ b/docs/implementation-specs/CR-009-jacoco-coverage-and-mapstruct.md
@@ -1,0 +1,59 @@
+# CR-009 Implementation Specification: JaCoCo Coverage and MapStruct
+
+## Scope
+
+This increment introduces JaCoCo XML consumption, report freshness checks, test-runner refresh, and
+MapStruct mapper attribution. Coverage diagnostics are produced as structured validation
+diagnostics so daemon/CLI renderers can display them through the existing validation result path.
+
+## Coverage Service
+
+`JacocoCoverageService` implements:
+
+- `currentCoverage(CoverageRequest)`
+- `freshness(CoverageRequest)`
+- `refreshCoverage(CoverageRequest)`
+
+Fresh reports are parsed directly. Missing, stale, or unknown reports trigger `TestRunner` through
+`refreshCoverage`.
+
+## Freshness
+
+Freshness compares the newest matching JaCoCo XML report against source files, test files, module
+POMs, and generated context files in the request. Missing reports are `ABSENT`; older reports are
+`STALE`.
+
+## JaCoCo XML
+
+`JacocoXmlParser` consumes XML class counters and stores line/branch coverage ratios by VM-style
+class name, for example:
+
+```text
+com/example/UserService
+```
+
+## Thresholds And Diagnostics
+
+`CoverageThresholdPolicy` supports threshold matching by:
+
+- annotation
+- class name
+- package pattern
+- source glob
+
+`CoverageDiagnosticService` emits `COVERAGE_FAILURE` diagnostics for classes below threshold.
+
+## MapStruct Attribution
+
+`MapStructCoverageAttributor` detects mapper interfaces by `@Mapper`, finds the generated
+`<MapperName>Impl` class, and attributes implementation coverage back to the mapper interface.
+
+Generated implementation files remain context; diagnostics are reported on mapper interfaces.
+
+## Tests
+
+- Fresh JaCoCo XML is consumed without rerunning tests.
+- Stale JaCoCo XML triggers the Docker/mvnd test runner.
+- MapStruct mapper diagnostics use generated implementation coverage and report against the mapper
+  interface.
+- Threshold matching supports annotation and glob.

--- a/src/main/java/de/zorro909/codecheck/coverage/ClassCoverage.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/ClassCoverage.java
@@ -1,0 +1,6 @@
+package de.zorro909.codecheck.coverage;
+
+public record ClassCoverage(String className,
+                            CoverageMetric line,
+                            CoverageMetric branch) {
+}

--- a/src/main/java/de/zorro909/codecheck/coverage/CoverageDiagnosticService.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/CoverageDiagnosticService.java
@@ -1,0 +1,56 @@
+package de.zorro909.codecheck.coverage;
+
+import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.validation.Diagnostic;
+import de.zorro909.codecheck.validation.DiagnosticKind;
+import de.zorro909.codecheck.validation.RuleId;
+import de.zorro909.codecheck.validation.SourcePosition;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CoverageDiagnosticService {
+
+    private static final RuleId COVERAGE_RULE = new RuleId("coverage.jacoco");
+
+    private final CoverageThresholdPolicy thresholdPolicy;
+    private final MapStructCoverageAttributor mapStructCoverageAttributor;
+
+    public CoverageDiagnosticService(CoverageThresholdPolicy thresholdPolicy,
+                                     MapStructCoverageAttributor mapStructCoverageAttributor) {
+        this.thresholdPolicy = thresholdPolicy;
+        this.mapStructCoverageAttributor = mapStructCoverageAttributor;
+    }
+
+    public List<Diagnostic> diagnostics(Path sourceFile,
+                                        String className,
+                                        CoverageSnapshot snapshot) {
+        CoverageThreshold threshold = thresholdPolicy.thresholdFor(sourceFile);
+        ClassCoverage coverage = mapStructCoverageAttributor.isMapper(sourceFile)
+                                 ? mapStructCoverageAttributor.attributedCoverage(sourceFile, snapshot)
+                                                              .orElse(null)
+                                 : snapshot.classCoverage(className).orElse(null);
+        if (coverage == null) {
+            return List.of();
+        }
+        List<Diagnostic> diagnostics = new ArrayList<>();
+        if (coverage.line().ratio() < threshold.line()) {
+            diagnostics.add(diagnostic(sourceFile, "Line coverage "
+                                                   + coverage.line().ratio()
+                                                   + " is below " + threshold.line()));
+        }
+        if (coverage.branch().ratio() < threshold.branch()) {
+            diagnostics.add(diagnostic(sourceFile, "Branch coverage "
+                                                   + coverage.branch().ratio()
+                                                   + " is below " + threshold.branch()));
+        }
+        return diagnostics;
+    }
+
+    private Diagnostic diagnostic(Path sourceFile, String message) {
+        return new Diagnostic(sourceFile, message, new SourcePosition(1, 1),
+                              ValidationError.Severity.HIGH, DiagnosticKind.COVERAGE_FAILURE,
+                              COVERAGE_RULE);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/coverage/CoverageFreshness.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/CoverageFreshness.java
@@ -1,0 +1,8 @@
+package de.zorro909.codecheck.coverage;
+
+public enum CoverageFreshness {
+    FRESH,
+    STALE,
+    ABSENT,
+    UNKNOWN
+}

--- a/src/main/java/de/zorro909/codecheck/coverage/CoverageMetric.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/CoverageMetric.java
@@ -1,0 +1,10 @@
+package de.zorro909.codecheck.coverage;
+
+public record CoverageMetric(int missed,
+                             int covered) {
+
+    public double ratio() {
+        int total = missed + covered;
+        return total == 0 ? 1.0 : (double) covered / total;
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/coverage/CoverageRequest.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/CoverageRequest.java
@@ -1,0 +1,23 @@
+package de.zorro909.codecheck.coverage;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public record CoverageRequest(List<Path> sourceFiles,
+                              List<Path> testFiles,
+                              List<Path> contextFiles,
+                              List<Path> buildFiles,
+                              List<Path> reportPaths) {
+
+    public CoverageRequest {
+        sourceFiles = normalize(sourceFiles);
+        testFiles = normalize(testFiles);
+        contextFiles = normalize(contextFiles);
+        buildFiles = normalize(buildFiles);
+        reportPaths = normalize(reportPaths);
+    }
+
+    private static List<Path> normalize(List<Path> paths) {
+        return paths.stream().map(path -> path.toAbsolutePath().normalize()).toList();
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/coverage/CoverageService.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/CoverageService.java
@@ -1,0 +1,10 @@
+package de.zorro909.codecheck.coverage;
+
+public interface CoverageService {
+
+    CoverageSnapshot currentCoverage(CoverageRequest request);
+
+    CoverageFreshness freshness(CoverageRequest request);
+
+    CoverageSnapshot refreshCoverage(CoverageRequest request);
+}

--- a/src/main/java/de/zorro909/codecheck/coverage/CoverageSnapshot.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/CoverageSnapshot.java
@@ -1,0 +1,15 @@
+package de.zorro909.codecheck.coverage;
+
+import java.util.Map;
+import java.util.Optional;
+
+public record CoverageSnapshot(Map<String, ClassCoverage> classes) {
+
+    public CoverageSnapshot {
+        classes = Map.copyOf(classes);
+    }
+
+    public Optional<ClassCoverage> classCoverage(String className) {
+        return Optional.ofNullable(classes.get(className));
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/coverage/CoverageThreshold.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/CoverageThreshold.java
@@ -1,0 +1,6 @@
+package de.zorro909.codecheck.coverage;
+
+public record CoverageThreshold(CoverageThresholdMatch match,
+                                double line,
+                                double branch) {
+}

--- a/src/main/java/de/zorro909/codecheck/coverage/CoverageThresholdMatch.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/CoverageThresholdMatch.java
@@ -1,0 +1,11 @@
+package de.zorro909.codecheck.coverage;
+
+public record CoverageThresholdMatch(String annotation,
+                                     String glob,
+                                     String className,
+                                     String packageName) {
+
+    public CoverageThresholdMatch(String annotation, String glob) {
+        this(annotation, glob, null, null);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/coverage/CoverageThresholdPolicy.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/CoverageThresholdPolicy.java
@@ -1,0 +1,110 @@
+package de.zorro909.codecheck.coverage;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+
+public class CoverageThresholdPolicy {
+
+    private final List<CoverageThreshold> thresholds;
+    private final CoverageThreshold fallback;
+
+    public CoverageThresholdPolicy(List<CoverageThreshold> thresholds,
+                                   CoverageThreshold fallback) {
+        this.thresholds = List.copyOf(thresholds);
+        this.fallback = fallback;
+    }
+
+    public CoverageThreshold thresholdFor(Path sourceFile) {
+        return thresholds.stream()
+                         .filter(threshold -> matches(threshold.match(), sourceFile))
+                         .max(Comparator.comparingInt(threshold -> specificity(threshold.match())))
+                         .orElse(fallback);
+    }
+
+    private boolean matches(CoverageThresholdMatch match, Path sourceFile) {
+        return annotationMatches(match.annotation(), sourceFile)
+               || globMatches(match.glob(), sourceFile)
+               || classMatches(match.className(), sourceFile)
+               || packageMatches(match.packageName(), sourceFile);
+    }
+
+    private boolean annotationMatches(String annotation, Path sourceFile) {
+        if (annotation == null || annotation.isBlank()) {
+            return false;
+        }
+        try {
+            String source = Files.readString(sourceFile);
+            String simpleName = annotation.substring(annotation.lastIndexOf('.') + 1);
+            return source.contains("@" + annotation) || source.contains("@" + simpleName);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to read " + sourceFile, e);
+        }
+    }
+
+    private boolean globMatches(String glob, Path sourceFile) {
+        return glob != null && !glob.isBlank()
+               && FileSystems.getDefault().getPathMatcher("glob:" + glob).matches(sourceFile);
+    }
+
+    private boolean classMatches(String className, Path sourceFile) {
+        if (className == null || className.isBlank()) {
+            return false;
+        }
+        String sourceClass = className(sourceFile);
+        return className.equals(sourceClass) || className.equals(sourceClass.replace('/', '.'));
+    }
+
+    private boolean packageMatches(String packageName, Path sourceFile) {
+        if (packageName == null || packageName.isBlank()) {
+            return false;
+        }
+        String sourceClass = className(sourceFile).replace('/', '.');
+        if (packageName.endsWith("..*")) {
+            String prefix = packageName.substring(0, packageName.length() - 3);
+            return sourceClass.startsWith(prefix + ".");
+        }
+        if (packageName.endsWith(".*")) {
+            String prefix = packageName.substring(0, packageName.length() - 2);
+            String remainder = sourceClass.substring(Math.min(sourceClass.length(), prefix.length()));
+            return sourceClass.startsWith(prefix + ".") && remainder.indexOf('.', 1) == -1;
+        }
+        return sourceClass.startsWith(packageName + ".");
+    }
+
+    private String className(Path sourceFile) {
+        try {
+            String source = Files.readString(sourceFile);
+            String packageName = java.util.regex.Pattern.compile("package\\s+([\\w.]+)\\s*;")
+                                                        .matcher(source)
+                                                        .results()
+                                                        .map(match -> match.group(1))
+                                                        .findFirst()
+                                                        .orElse("");
+            String simpleName = sourceFile.getFileName().toString().replaceFirst("\\.java$", "");
+            return packageName.isBlank() ? simpleName : packageName + "." + simpleName;
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to read " + sourceFile, e);
+        }
+    }
+
+    private int specificity(CoverageThresholdMatch match) {
+        int score = 0;
+        if (match.annotation() != null && !match.annotation().isBlank()) {
+            score += 2;
+        }
+        if (match.glob() != null && !match.glob().isBlank()) {
+            score += 1;
+        }
+        if (match.packageName() != null && !match.packageName().isBlank()) {
+            score += 2;
+        }
+        if (match.className() != null && !match.className().isBlank()) {
+            score += 3;
+        }
+        return score;
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/coverage/CoverageThresholdPolicy.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/CoverageThresholdPolicy.java
@@ -26,10 +26,36 @@ public class CoverageThresholdPolicy {
     }
 
     private boolean matches(CoverageThresholdMatch match, Path sourceFile) {
-        return annotationMatches(match.annotation(), sourceFile)
-               || globMatches(match.glob(), sourceFile)
-               || classMatches(match.className(), sourceFile)
-               || packageMatches(match.packageName(), sourceFile);
+        boolean anyCriterionSet = false;
+        if (isSet(match.annotation())) {
+            anyCriterionSet = true;
+            if (!annotationMatches(match.annotation(), sourceFile)) {
+                return false;
+            }
+        }
+        if (isSet(match.glob())) {
+            anyCriterionSet = true;
+            if (!globMatches(match.glob(), sourceFile)) {
+                return false;
+            }
+        }
+        if (isSet(match.className())) {
+            anyCriterionSet = true;
+            if (!classMatches(match.className(), sourceFile)) {
+                return false;
+            }
+        }
+        if (isSet(match.packageName())) {
+            anyCriterionSet = true;
+            if (!packageMatches(match.packageName(), sourceFile)) {
+                return false;
+            }
+        }
+        return anyCriterionSet;
+    }
+
+    private boolean isSet(String criterion) {
+        return criterion != null && !criterion.isBlank();
     }
 
     private boolean annotationMatches(String annotation, Path sourceFile) {

--- a/src/main/java/de/zorro909/codecheck/coverage/JacocoCoverageService.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/JacocoCoverageService.java
@@ -1,0 +1,86 @@
+package de.zorro909.codecheck.coverage;
+
+import de.zorro909.codecheck.runner.TestRunRequest;
+import de.zorro909.codecheck.runner.TestRunner;
+import jakarta.inject.Singleton;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+
+@Singleton
+public class JacocoCoverageService implements CoverageService {
+
+    private final TestRunner testRunner;
+    private final JacocoXmlParser parser;
+
+    public JacocoCoverageService(TestRunner testRunner) {
+        this(testRunner, new JacocoXmlParser());
+    }
+
+    JacocoCoverageService(TestRunner testRunner, JacocoXmlParser parser) {
+        this.testRunner = testRunner;
+        this.parser = parser;
+    }
+
+    @Override
+    public CoverageSnapshot currentCoverage(CoverageRequest request) {
+        CoverageFreshness freshness = freshness(request);
+        if (freshness == CoverageFreshness.FRESH) {
+            return parser.parse(newestReport(existing(request.reportPaths())));
+        }
+        return refreshCoverage(request);
+    }
+
+    @Override
+    public CoverageFreshness freshness(CoverageRequest request) {
+        List<Path> existingReports = existing(request.reportPaths());
+        if (existingReports.isEmpty()) {
+            return CoverageFreshness.ABSENT;
+        }
+        Instant newestReport = modified(newestReport(existingReports));
+        List<Path> inputs = java.util.stream.Stream.of(request.sourceFiles(), request.testFiles(),
+                                                       request.contextFiles(), request.buildFiles())
+                                                   .flatMap(List::stream)
+                                                   .filter(Files::exists)
+                                                   .toList();
+        if (inputs.isEmpty()) {
+            return CoverageFreshness.FRESH;
+        }
+        Instant newestInput = inputs.stream().map(this::modified).max(Comparator.naturalOrder())
+                                    .orElse(Instant.EPOCH);
+        return newestReport.isBefore(newestInput) ? CoverageFreshness.STALE : CoverageFreshness.FRESH;
+    }
+
+    @Override
+    public CoverageSnapshot refreshCoverage(CoverageRequest request) {
+        var result = testRunner.runTests(TestRunRequest.full());
+        if (!result.success()) {
+            throw new IllegalStateException("Unable to refresh JaCoCo coverage; test run exited with "
+                                            + result.exitCode());
+        }
+        return parser.parse(newestReport(existing(request.reportPaths())));
+    }
+
+    private List<Path> existing(List<Path> paths) {
+        return paths.stream().filter(Files::exists).toList();
+    }
+
+    private Path newestReport(List<Path> reports) {
+        return reports.stream().max(Comparator.comparing(this::modified))
+                      .orElseThrow(() -> new IllegalStateException("No JaCoCo report available"));
+    }
+
+    private Instant modified(Path path) {
+        try {
+            FileTime time = Files.getLastModifiedTime(path);
+            return time.toInstant();
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to inspect " + path, e);
+        }
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/coverage/JacocoXmlParser.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/JacocoXmlParser.java
@@ -12,10 +12,14 @@ public class JacocoXmlParser {
 
     public CoverageSnapshot parse(Path report) {
         try {
-            Element root = DocumentBuilderFactory.newInstance()
-                                                 .newDocumentBuilder()
-                                                 .parse(report.toFile())
-                                                 .getDocumentElement();
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd",
+                               false);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            Element root = factory.newDocumentBuilder()
+                                  .parse(report.toFile())
+                                  .getDocumentElement();
             NodeList classes = root.getElementsByTagName("class");
             Map<String, ClassCoverage> coverage = new HashMap<>();
             for (int i = 0; i < classes.getLength(); i++) {

--- a/src/main/java/de/zorro909/codecheck/coverage/JacocoXmlParser.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/JacocoXmlParser.java
@@ -1,0 +1,44 @@
+package de.zorro909.codecheck.coverage;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JacocoXmlParser {
+
+    public CoverageSnapshot parse(Path report) {
+        try {
+            Element root = DocumentBuilderFactory.newInstance()
+                                                 .newDocumentBuilder()
+                                                 .parse(report.toFile())
+                                                 .getDocumentElement();
+            NodeList classes = root.getElementsByTagName("class");
+            Map<String, ClassCoverage> coverage = new HashMap<>();
+            for (int i = 0; i < classes.getLength(); i++) {
+                Element classElement = (Element) classes.item(i);
+                String className = classElement.getAttribute("name");
+                coverage.put(className, new ClassCoverage(
+                        className, counter(classElement, "LINE"), counter(classElement, "BRANCH")));
+            }
+            return new CoverageSnapshot(coverage);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to parse JaCoCo report " + report, e);
+        }
+    }
+
+    private CoverageMetric counter(Element classElement, String type) {
+        NodeList counters = classElement.getElementsByTagName("counter");
+        for (int i = 0; i < counters.getLength(); i++) {
+            Element counter = (Element) counters.item(i);
+            if (type.equals(counter.getAttribute("type"))) {
+                return new CoverageMetric(Integer.parseInt(counter.getAttribute("missed")),
+                                          Integer.parseInt(counter.getAttribute("covered")));
+            }
+        }
+        return new CoverageMetric(0, 0);
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/coverage/MapStructCoverageAttributor.java
+++ b/src/main/java/de/zorro909/codecheck/coverage/MapStructCoverageAttributor.java
@@ -1,0 +1,48 @@
+package de.zorro909.codecheck.coverage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class MapStructCoverageAttributor {
+
+    private static final Pattern PACKAGE = Pattern.compile("package\\s+([\\w.]+)\\s*;");
+    private static final Pattern TYPE = Pattern.compile("interface\\s+(\\w+)");
+
+    public boolean isMapper(Path sourceFile) {
+        try {
+            String source = Files.readString(sourceFile);
+            return source.contains("@Mapper") || source.contains("@org.mapstruct.Mapper");
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to read " + sourceFile, e);
+        }
+    }
+
+    public Optional<ClassCoverage> attributedCoverage(Path mapperInterface,
+                                                      CoverageSnapshot snapshot) {
+        String implName = implementationClassName(mapperInterface);
+        return snapshot.classCoverage(implName).or(() -> snapshot.classCoverage(
+                implName.replace('/', '.')));
+    }
+
+    public String implementationClassName(Path mapperInterface) {
+        try {
+            String source = Files.readString(mapperInterface);
+            String packageName = match(PACKAGE, source).orElse("");
+            String typeName = match(TYPE, source).orElseThrow();
+            String qualified = packageName.isBlank() ? typeName + "Impl"
+                                                     : packageName + "." + typeName + "Impl";
+            return qualified.replace('.', '/');
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to read " + mapperInterface, e);
+        }
+    }
+
+    private Optional<String> match(Pattern pattern, String source) {
+        Matcher matcher = pattern.matcher(source);
+        return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/coverage/CoverageDiagnosticServiceTest.java
+++ b/src/test/java/de/zorro909/codecheck/coverage/CoverageDiagnosticServiceTest.java
@@ -1,0 +1,54 @@
+package de.zorro909.codecheck.coverage;
+
+import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.validation.DiagnosticKind;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CoverageDiagnosticServiceTest {
+
+    @Test
+    void mapStructMapperDiagnosticsUseGeneratedImplementationCoverage(@TempDir Path repo)
+            throws Exception {
+        Path mapper = write(repo.resolve("src/main/java/com/example/UserMapper.java"), """
+                package com.example;
+
+                import org.mapstruct.Mapper;
+
+                @Mapper
+                public interface UserMapper {}
+                """);
+        CoverageSnapshot snapshot = new CoverageSnapshot(Map.of(
+                "com/example/UserMapperImpl",
+                new ClassCoverage("com/example/UserMapperImpl",
+                                  new CoverageMetric(3, 7),
+                                  new CoverageMetric(2, 2))));
+        CoverageThreshold fallback = new CoverageThreshold(new CoverageThresholdMatch(null, null), 0.80, 0.70);
+        CoverageDiagnosticService service = new CoverageDiagnosticService(
+                new CoverageThresholdPolicy(List.of(), fallback), new MapStructCoverageAttributor());
+
+        var diagnostics = service.diagnostics(mapper, "com/example/UserMapper", snapshot);
+
+        assertThat(diagnostics).hasSize(2);
+        assertThat(diagnostics).allSatisfy(diagnostic -> {
+            assertThat(diagnostic.file()).isEqualTo(mapper);
+            assertThat(diagnostic.kind()).isEqualTo(DiagnosticKind.COVERAGE_FAILURE);
+            assertThat(diagnostic.severity()).isEqualTo(ValidationError.Severity.HIGH);
+        });
+        assertThat(diagnostics).extracting(diagnostic -> diagnostic.ruleId().value())
+                               .containsOnly("coverage.jacoco");
+    }
+
+    private static Path write(Path path, String content) throws IOException {
+        Files.createDirectories(path.getParent());
+        return Files.writeString(path, content);
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/coverage/CoverageThresholdPolicyTest.java
+++ b/src/test/java/de/zorro909/codecheck/coverage/CoverageThresholdPolicyTest.java
@@ -60,6 +60,21 @@ class CoverageThresholdPolicyTest {
         assertThat(policy.thresholdFor(service)).isEqualTo(classThreshold);
     }
 
+    @Test
+    void thresholdWithMultipleCriteriaRequiresAllOfThemToMatch(@TempDir Path repo)
+            throws Exception {
+        Path service = write(repo.resolve("src/main/java/com/example/service/UserService.java"),
+                             "package com.example.service; class UserService {}");
+        CoverageThreshold combined = new CoverageThreshold(
+                new CoverageThresholdMatch("org.mapstruct.Mapper", null, null,
+                                           "com.example.service..*"), 0.95, 0.90);
+        CoverageThreshold fallback = new CoverageThreshold(new CoverageThresholdMatch(null, null),
+                                                           0.50, 0.40);
+        CoverageThresholdPolicy policy = new CoverageThresholdPolicy(List.of(combined), fallback);
+
+        assertThat(policy.thresholdFor(service)).isEqualTo(fallback);
+    }
+
     private static Path write(Path path, String content) throws IOException {
         Files.createDirectories(path.getParent());
         return Files.writeString(path, content);

--- a/src/test/java/de/zorro909/codecheck/coverage/CoverageThresholdPolicyTest.java
+++ b/src/test/java/de/zorro909/codecheck/coverage/CoverageThresholdPolicyTest.java
@@ -1,0 +1,67 @@
+package de.zorro909.codecheck.coverage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CoverageThresholdPolicyTest {
+
+    @Test
+    void annotationThresholdWinsOverGlobThreshold(@TempDir Path repo) throws Exception {
+        Path mapper = write(repo.resolve("src/main/java/com/example/mapper/UserMapper.java"), """
+                package com.example.mapper;
+
+                import org.mapstruct.Mapper;
+
+                @Mapper
+                interface UserMapper {}
+                """);
+        CoverageThreshold annotationThreshold = new CoverageThreshold(
+                new CoverageThresholdMatch("org.mapstruct.Mapper", null), 0.95, 0.90);
+        CoverageThreshold globThreshold = new CoverageThreshold(
+                new CoverageThresholdMatch(null, "**/mapper/*.java"), 0.70, 0.60);
+        CoverageThreshold fallback = new CoverageThreshold(new CoverageThresholdMatch(null, null), 0.50, 0.40);
+        CoverageThresholdPolicy policy = new CoverageThresholdPolicy(
+                List.of(globThreshold, annotationThreshold), fallback);
+
+        assertThat(policy.thresholdFor(mapper)).isEqualTo(annotationThreshold);
+    }
+
+    @Test
+    void globThresholdMatchesSourcePath(@TempDir Path repo) throws Exception {
+        Path service = write(repo.resolve("src/main/java/com/example/service/UserService.java"),
+                             "package com.example.service; class UserService {}");
+        CoverageThreshold globThreshold = new CoverageThreshold(
+                new CoverageThresholdMatch(null, "**/service/*.java"), 0.80, 0.75);
+        CoverageThreshold fallback = new CoverageThreshold(new CoverageThresholdMatch(null, null), 0.50, 0.40);
+        CoverageThresholdPolicy policy = new CoverageThresholdPolicy(List.of(globThreshold), fallback);
+
+        assertThat(policy.thresholdFor(service)).isEqualTo(globThreshold);
+    }
+
+    @Test
+    void classThresholdWinsOverPackageThreshold(@TempDir Path repo) throws Exception {
+        Path service = write(repo.resolve("src/main/java/com/example/service/UserService.java"),
+                             "package com.example.service; class UserService {}");
+        CoverageThreshold packageThreshold = new CoverageThreshold(
+                new CoverageThresholdMatch(null, null, null, "com.example.service..*"), 0.80, 0.75);
+        CoverageThreshold classThreshold = new CoverageThreshold(
+                new CoverageThresholdMatch(null, null, "com.example.service.UserService", null), 0.95, 0.90);
+        CoverageThreshold fallback = new CoverageThreshold(new CoverageThresholdMatch(null, null), 0.50, 0.40);
+        CoverageThresholdPolicy policy = new CoverageThresholdPolicy(
+                List.of(packageThreshold, classThreshold), fallback);
+
+        assertThat(policy.thresholdFor(service)).isEqualTo(classThreshold);
+    }
+
+    private static Path write(Path path, String content) throws IOException {
+        Files.createDirectories(path.getParent());
+        return Files.writeString(path, content);
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/coverage/JacocoCoverageServiceTest.java
+++ b/src/test/java/de/zorro909/codecheck/coverage/JacocoCoverageServiceTest.java
@@ -66,6 +66,8 @@ class JacocoCoverageServiceTest {
     private static String report(String className, int lineMissed, int lineCovered,
                                  int branchMissed, int branchCovered) {
         return """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
                 <report name="unit">
                   <package name="com/example">
                     <class name="%s" sourcefilename="Foo.java">

--- a/src/test/java/de/zorro909/codecheck/coverage/JacocoCoverageServiceTest.java
+++ b/src/test/java/de/zorro909/codecheck/coverage/JacocoCoverageServiceTest.java
@@ -1,0 +1,106 @@
+package de.zorro909.codecheck.coverage;
+
+import de.zorro909.codecheck.runner.TestRunRequest;
+import de.zorro909.codecheck.runner.TestRunResult;
+import de.zorro909.codecheck.runner.TestRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JacocoCoverageServiceTest {
+
+    @Test
+    void freshReportIsParsedWithoutRunningTests(@TempDir Path repo) throws Exception {
+        Path source = write(repo.resolve("src/main/java/com/example/Foo.java"), "class Foo {}");
+        Path report = write(repo.resolve("target/site/jacoco/jacoco.xml"),
+                            report("com/example/Foo", 1, 3, 2, 2));
+        Files.setLastModifiedTime(source, FileTime.from(Instant.parse("2026-01-01T00:00:00Z")));
+        Files.setLastModifiedTime(report, FileTime.from(Instant.parse("2026-01-01T00:00:10Z")));
+        RecordingRunner runner = new RecordingRunner(report, report("com/example/Foo", 0, 1, 0, 1));
+        JacocoCoverageService service = new JacocoCoverageService(runner);
+
+        CoverageSnapshot snapshot = service.currentCoverage(new CoverageRequest(
+                List.of(source), List.of(), List.of(), List.of(),
+                List.of(repo.resolve("missing.xml"), report)));
+
+        assertThat(runner.requests).isEmpty();
+        assertThat(snapshot.classCoverage("com/example/Foo"))
+                .get()
+                .extracting(coverage -> coverage.line().ratio())
+                .isEqualTo(0.75);
+    }
+
+    @Test
+    void staleReportRunsTestsAndParsesRefreshedReport(@TempDir Path repo) throws Exception {
+        Path source = write(repo.resolve("src/main/java/com/example/Foo.java"), "class Foo { int value; }");
+        Path report = write(repo.resolve("target/site/jacoco/jacoco.xml"),
+                            report("com/example/Foo", 4, 0, 1, 0));
+        Files.setLastModifiedTime(report, FileTime.from(Instant.parse("2026-01-01T00:00:00Z")));
+        Files.setLastModifiedTime(source, FileTime.from(Instant.parse("2026-01-01T00:00:10Z")));
+        RecordingRunner runner = new RecordingRunner(report, report("com/example/Foo", 1, 9, 0, 2));
+        JacocoCoverageService service = new JacocoCoverageService(runner);
+
+        CoverageSnapshot snapshot = service.currentCoverage(new CoverageRequest(
+                List.of(source), List.of(), List.of(), List.of(), List.of(report)));
+
+        assertThat(runner.requests).containsExactly(TestRunRequest.full());
+        assertThat(snapshot.classCoverage("com/example/Foo"))
+                .get()
+                .extracting(coverage -> coverage.line().ratio(), coverage -> coverage.branch().ratio())
+                .containsExactly(0.9, 1.0);
+    }
+
+    private static Path write(Path path, String content) throws IOException {
+        Files.createDirectories(path.getParent());
+        return Files.writeString(path, content);
+    }
+
+    private static String report(String className, int lineMissed, int lineCovered,
+                                 int branchMissed, int branchCovered) {
+        return """
+                <report name="unit">
+                  <package name="com/example">
+                    <class name="%s" sourcefilename="Foo.java">
+                      <counter type="LINE" missed="%d" covered="%d"/>
+                      <counter type="BRANCH" missed="%d" covered="%d"/>
+                    </class>
+                  </package>
+                </report>
+                """.formatted(className, lineMissed, lineCovered, branchMissed, branchCovered);
+    }
+
+    private static final class RecordingRunner implements TestRunner {
+        private final Path report;
+        private final String refreshedReport;
+        private final List<TestRunRequest> requests = new java.util.ArrayList<>();
+
+        private RecordingRunner(Path report, String refreshedReport) {
+            this.report = report;
+            this.refreshedReport = refreshedReport;
+        }
+
+        @Override
+        public TestRunResult runTests(TestRunRequest request) {
+            requests.add(request);
+            try {
+                Files.writeString(report, refreshedReport);
+                Files.setLastModifiedTime(report, FileTime.from(Instant.parse("2026-01-01T00:01:00Z")));
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+            return new TestRunResult(true, 0, "", "", "container", List.of("mvnd", "test", "jacoco:report"));
+        }
+
+        @Override
+        public void stop() {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add JaCoCo XML coverage snapshot parsing and freshness-aware coverage refresh through the test runner
- add threshold matching by annotation, glob, class, and package
- add MapStruct generated implementation attribution with coverage diagnostics reported on mapper interfaces

## Tests
- ./mvnw test -Dtest=JacocoCoverageServiceTest,CoverageThresholdPolicyTest,CoverageDiagnosticServiceTest
- ./mvnw test