### PR TITLE
CR-010: Severity reporting and pre-commit policy

### DIFF
--- a/docs/implementation-specs/CR-010-severity-reporting-and-precommit.md
+++ b/docs/implementation-specs/CR-010-severity-reporting-and-precommit.md
@@ -1,0 +1,37 @@
+# CR-010 Implementation Specification: Severity, Reporting, and Pre-Commit Behavior
+
+## Scope
+
+This increment makes mode-specific severity behavior explicit for command rendering and exit
+decisions. Validation remains structured internally and the validation engine does not terminate the
+process.
+
+## Severity Policy
+
+`ModeSeverityPolicy` defines visibility and blocking behavior by `ValidationMode`.
+
+- Assistant and interactive modes display LOW, MEDIUM, and HIGH diagnostics.
+- Batch mode displays all diagnostics, but only HIGH blocks.
+- Pre-commit displays HIGH and MEDIUM diagnostics, hides LOW diagnostics, and only HIGH blocks.
+
+## Terminal Reporting
+
+`TerminalDiagnosticRenderer` renders human terminal output from structured diagnostics grouped by
+file. It applies `ModeSeverityPolicy` before printing diagnostics and prints a concise blocking exit
+reason when the mode will fail.
+
+JSON and IDE renderers remain deferred, but mode filtering is isolated from command orchestration so
+other renderers can reuse the same policy.
+
+## Command Behavior
+
+`CodeCheckCommandService` continues to return `CommandOutcome` instead of calling `System.exit`.
+Batch and pre-commit exits are calculated from `ModeSeverityPolicy.blocks(...)`.
+
+## Tests
+
+- Pre-commit hides LOW diagnostics, prints MEDIUM diagnostics, and blocks on HIGH diagnostics.
+- Batch exits nonzero when HIGH diagnostics exist.
+- HIGH parse diagnostics from the validation engine block pre-commit.
+- MEDIUM symbol diagnostics print in pre-commit without blocking.
+- Assistant-mode validation results retain LOW, MEDIUM, and HIGH diagnostics.

--- a/src/main/java/de/zorro909/codecheck/command/CodeCheckCommandService.java
+++ b/src/main/java/de/zorro909/codecheck/command/CodeCheckCommandService.java
@@ -8,6 +8,8 @@ import de.zorro909.codecheck.checks.ValidationError;
 import de.zorro909.codecheck.config.CodeCheckConfigLoader;
 import de.zorro909.codecheck.config.ConfigException;
 import de.zorro909.codecheck.config.ConfigOverrides;
+import de.zorro909.codecheck.reporting.ModeSeverityPolicy;
+import de.zorro909.codecheck.reporting.TerminalDiagnosticRenderer;
 import de.zorro909.codecheck.selector.FileSelector;
 import de.zorro909.codecheck.validation.Diagnostic;
 import de.zorro909.codecheck.validation.ValidationEngine;
@@ -20,7 +22,6 @@ import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -32,6 +33,7 @@ public class CodeCheckCommandService {
     private final ValidationEngine validationEngine;
     private final ChangeSetService changeSetService;
     private final CodeCheckConfigLoader configLoader;
+    private final TerminalDiagnosticRenderer diagnosticRenderer;
     private final PrintStream out;
     private final PrintStream err;
 
@@ -42,14 +44,16 @@ public class CodeCheckCommandService {
                                    ChangeSetService changeSetService,
                                    CodeCheckConfigLoader configLoader) {
         this(assistantDaemonController, validationCheckPipeline, validationEngine,
-             changeSetService, configLoader, System.out, System.err);
+             changeSetService, configLoader,
+             new TerminalDiagnosticRenderer(new ModeSeverityPolicy()), System.out, System.err);
     }
 
     public CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
                                    ValidationCheckPipeline validationCheckPipeline,
                                    FileSelector fileSelector) {
-        this(assistantDaemonController, validationCheckPipeline, fromFileSelector(fileSelector),
-             CodeCheckConfigLoader.defaultsOnly(), System.out, System.err);
+        this(assistantDaemonController, validationCheckPipeline, null, fromFileSelector(fileSelector),
+             CodeCheckConfigLoader.defaultsOnly(),
+             new TerminalDiagnosticRenderer(new ModeSeverityPolicy()), System.out, System.err);
     }
 
     CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
@@ -57,8 +61,9 @@ public class CodeCheckCommandService {
                             FileSelector fileSelector,
                             PrintStream out,
                             PrintStream err) {
-        this(assistantDaemonController, validationCheckPipeline, fromFileSelector(fileSelector),
-             CodeCheckConfigLoader.defaultsOnly(), out, err);
+        this(assistantDaemonController, validationCheckPipeline, null, fromFileSelector(fileSelector),
+             CodeCheckConfigLoader.defaultsOnly(),
+             new TerminalDiagnosticRenderer(new ModeSeverityPolicy()), out, err);
     }
 
     CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
@@ -67,8 +72,8 @@ public class CodeCheckCommandService {
                             CodeCheckConfigLoader configLoader,
                             PrintStream out,
                             PrintStream err) {
-        this(assistantDaemonController, validationCheckPipeline, fromFileSelector(fileSelector),
-             configLoader, out, err);
+        this(assistantDaemonController, validationCheckPipeline, null, fromFileSelector(fileSelector),
+             configLoader, new TerminalDiagnosticRenderer(new ModeSeverityPolicy()), out, err);
     }
 
     CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
@@ -78,7 +83,7 @@ public class CodeCheckCommandService {
                             PrintStream out,
                             PrintStream err) {
         this(assistantDaemonController, validationCheckPipeline, null, changeSetService,
-             configLoader, out, err);
+             configLoader, new TerminalDiagnosticRenderer(new ModeSeverityPolicy()), out, err);
     }
 
     CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
@@ -88,11 +93,24 @@ public class CodeCheckCommandService {
                             CodeCheckConfigLoader configLoader,
                             PrintStream out,
                             PrintStream err) {
+        this(assistantDaemonController, validationCheckPipeline, validationEngine, changeSetService,
+             configLoader, new TerminalDiagnosticRenderer(new ModeSeverityPolicy()), out, err);
+    }
+
+    CodeCheckCommandService(AssistantDaemonController assistantDaemonController,
+                            ValidationCheckPipeline validationCheckPipeline,
+                            ValidationEngine validationEngine,
+                            ChangeSetService changeSetService,
+                            CodeCheckConfigLoader configLoader,
+                            TerminalDiagnosticRenderer diagnosticRenderer,
+                            PrintStream out,
+                            PrintStream err) {
         this.assistantDaemonController = assistantDaemonController;
         this.validationCheckPipeline = validationCheckPipeline;
         this.validationEngine = validationEngine;
         this.changeSetService = changeSetService;
         this.configLoader = configLoader;
+        this.diagnosticRenderer = diagnosticRenderer;
         this.out = out;
         this.err = err;
     }
@@ -118,7 +136,7 @@ public class CodeCheckCommandService {
             Map<Path, List<ValidationError>> errorsMap = collectErrors(
                     changeSetService.currentInteractiveCheckChangeSet(),
                     ValidationMode.INTERACTIVE);
-            printOverview(errorsMap, _ -> true);
+            diagnosticRenderer.render(ValidationMode.INTERACTIVE, errorsMap, out);
 
             if (errorsMap.isEmpty()) {
                 return CommandOutcome.success();
@@ -141,15 +159,13 @@ public class CodeCheckCommandService {
     }
 
     public CommandOutcome runBatchCheck() {
-        return runNonInteractive("batch check", ValidationMode.BATCH,
-                                 changeSetService::currentInteractiveCheckChangeSet,
-                                 _ -> true);
+        return runNonInteractive("batch check", changeSetService::currentInteractiveCheckChangeSet,
+                                 ValidationMode.BATCH);
     }
 
     public CommandOutcome runPreCommit() {
-        return runNonInteractive("pre-commit check", ValidationMode.PRE_COMMIT,
-                                 changeSetService::preCommitChangeSet,
-                                 error -> error.severity() != ValidationError.Severity.LOW);
+        return runNonInteractive("pre-commit check", changeSetService::preCommitChangeSet,
+                                 ValidationMode.PRE_COMMIT);
     }
 
     public CommandOutcome printStatus() {
@@ -174,17 +190,16 @@ public class CodeCheckCommandService {
     }
 
     private CommandOutcome runNonInteractive(String label,
-                                             ValidationMode mode,
                                              Supplier<ChangeSet> changeSetSupplier,
-                                             Predicate<ValidationError> diagnosticFilter) {
+                                             ValidationMode mode) {
         if (!loadConfig()) {
             return CommandOutcome.failure();
         }
         try {
-            Map<Path, List<ValidationError>> errorsMap = collectErrors(changeSetSupplier.get(),
-                                                                       mode);
-            printOverview(errorsMap, diagnosticFilter);
-            return hasHighSeverity(errorsMap) ? CommandOutcome.failure() : CommandOutcome.success();
+            Map<Path, List<ValidationError>> errorsMap = collectErrors(changeSetSupplier.get(), mode);
+            diagnosticRenderer.render(mode, errorsMap, out);
+            return diagnosticRenderer.blocks(mode, errorsMap) ? CommandOutcome.failure()
+                                                              : CommandOutcome.success();
         } catch (IOException e) {
             err.println("Failed to run " + label + ": " + e.getMessage());
             return CommandOutcome.failure();
@@ -208,42 +223,6 @@ public class CodeCheckCommandService {
         try (Stream<Path> changedFiles = changeSet.paths()) {
             return validationCheckPipeline.checkForErrors(changedFiles);
         }
-    }
-
-    private void printOverview(Map<Path, List<ValidationError>> errorsMap,
-                               Predicate<ValidationError> diagnosticFilter) {
-        out.println("Overview of code checks:");
-        out.println("------------------------");
-        if (errorsMap.isEmpty()) {
-            out.println("No validation errors found.");
-            return;
-        }
-
-        long visibleErrors = errorsMap.values()
-                                      .stream()
-                                      .flatMap(List::stream)
-                                      .filter(diagnosticFilter)
-                                      .count();
-
-        if (visibleErrors == 0) {
-            out.println("No blocking validation errors found.");
-            return;
-        }
-
-        out.println("Validation diagnostics:");
-        errorsMap.values()
-                 .stream()
-                 .flatMap(List::stream)
-                 .filter(diagnosticFilter)
-                 .map(ValidationError::toString)
-                 .forEach(out::println);
-    }
-
-    private boolean hasHighSeverity(Map<Path, List<ValidationError>> errorsMap) {
-        return errorsMap.values()
-                        .stream()
-                        .flatMap(List::stream)
-                        .anyMatch(error -> error.severity() == ValidationError.Severity.HIGH);
     }
 
     private boolean loadConfig() {

--- a/src/main/java/de/zorro909/codecheck/reporting/ModeSeverityPolicy.java
+++ b/src/main/java/de/zorro909/codecheck/reporting/ModeSeverityPolicy.java
@@ -1,0 +1,24 @@
+package de.zorro909.codecheck.reporting;
+
+import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.validation.ValidationMode;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ModeSeverityPolicy {
+
+    public boolean visible(ValidationMode mode, ValidationError.Severity severity) {
+        return switch (mode) {
+            case ASSISTANT, INTERACTIVE, BATCH -> true;
+            case PRE_COMMIT -> severity != ValidationError.Severity.LOW;
+        };
+    }
+
+    public boolean blocks(ValidationMode mode, ValidationError.Severity severity) {
+        return switch (mode) {
+            case BATCH, PRE_COMMIT -> severity == ValidationError.Severity.HIGH;
+            case INTERACTIVE -> true;
+            case ASSISTANT -> false;
+        };
+    }
+}

--- a/src/main/java/de/zorro909/codecheck/reporting/TerminalDiagnosticRenderer.java
+++ b/src/main/java/de/zorro909/codecheck/reporting/TerminalDiagnosticRenderer.java
@@ -1,0 +1,62 @@
+package de.zorro909.codecheck.reporting;
+
+import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.validation.ValidationMode;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+@Singleton
+public class TerminalDiagnosticRenderer {
+
+    private final ModeSeverityPolicy severityPolicy;
+
+    @Inject
+    public TerminalDiagnosticRenderer(ModeSeverityPolicy severityPolicy) {
+        this.severityPolicy = severityPolicy;
+    }
+
+    public void render(ValidationMode mode,
+                       Map<Path, List<ValidationError>> errorsMap,
+                       PrintStream out) {
+        out.println("Overview of code checks:");
+        out.println("------------------------");
+        if (errorsMap.isEmpty()) {
+            out.println("No validation errors found.");
+            return;
+        }
+
+        List<ValidationError> visibleErrors = errorsMap.values()
+                                                       .stream()
+                                                       .flatMap(List::stream)
+                                                       .filter(error -> severityPolicy.visible(mode,
+                                                                                               error.severity()))
+                                                       .toList();
+
+        if (visibleErrors.isEmpty()) {
+            out.println("No blocking validation errors found.");
+            return;
+        }
+
+        out.println("Validation diagnostics:");
+        visibleErrors.stream()
+                     .map(ValidationError::toString)
+                     .forEach(out::println);
+
+        if ((mode == ValidationMode.BATCH || mode == ValidationMode.PRE_COMMIT)
+            && blocks(mode, errorsMap)) {
+            out.println("Blocking HIGH diagnostics found; exiting with failure.");
+        }
+    }
+
+    public boolean blocks(ValidationMode mode, Map<Path, List<ValidationError>> errorsMap) {
+        return errorsMap.values()
+                        .stream()
+                        .flatMap(List::stream)
+                        .anyMatch(error -> severityPolicy.blocks(mode, error.severity()));
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/command/CodeCheckCommandServiceTest.java
+++ b/src/test/java/de/zorro909/codecheck/command/CodeCheckCommandServiceTest.java
@@ -4,6 +4,10 @@ import com.github.javaparser.Position;
 import de.zorro909.codecheck.ValidationCheckPipeline;
 import de.zorro909.codecheck.actions.FixAction;
 import de.zorro909.codecheck.actions.PostAction;
+import de.zorro909.codecheck.changeset.ChangeSet;
+import de.zorro909.codecheck.changeset.ChangeSetEntry;
+import de.zorro909.codecheck.changeset.ChangeSetService;
+import de.zorro909.codecheck.changeset.GitFileStatus;
 import de.zorro909.codecheck.checks.CodeCheck;
 import de.zorro909.codecheck.checks.ValidationError;
 import de.zorro909.codecheck.config.CodeCheckConfig;
@@ -11,6 +15,14 @@ import de.zorro909.codecheck.config.CodeCheckConfigLoader;
 import de.zorro909.codecheck.config.ConfigException;
 import de.zorro909.codecheck.config.ConfigOverrides;
 import de.zorro909.codecheck.selector.FileSelector;
+import de.zorro909.codecheck.validation.Diagnostic;
+import de.zorro909.codecheck.validation.DiagnosticKind;
+import de.zorro909.codecheck.validation.FileValidationResult;
+import de.zorro909.codecheck.validation.RuleId;
+import de.zorro909.codecheck.validation.SourcePosition;
+import de.zorro909.codecheck.validation.ValidationEngine;
+import de.zorro909.codecheck.validation.ValidationMode;
+import de.zorro909.codecheck.validation.ValidationResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -152,7 +164,8 @@ class CodeCheckCommandServiceTest {
         assertThat(outcome.exitCode()).isEqualTo(1);
         assertThat(output()).doesNotContain("Low detail")
                             .contains("Medium warning")
-                            .contains("High failure");
+                            .contains("High failure")
+                            .contains("Blocking HIGH diagnostics found");
     }
 
     @Test
@@ -165,6 +178,49 @@ class CodeCheckCommandServiceTest {
 
         assertThat(outcome.exitCode()).isZero();
         assertThat(output()).contains("Medium warning");
+    }
+
+    @Test
+    void highParseErrorFromValidationEngineBlocksPreCommit(@TempDir Path tempDir)
+            throws Exception {
+        Path file = javaFile(tempDir);
+        CodeCheckCommandService service = createEngineService(file, List.of(
+                diagnostic(file, "Parse failed", ValidationError.Severity.HIGH,
+                           DiagnosticKind.PARSE_ERROR)));
+
+        CommandOutcome outcome = service.runPreCommit();
+
+        assertThat(outcome.exitCode()).isEqualTo(1);
+        assertThat(output()).contains("Parse failed")
+                            .contains("Blocking HIGH diagnostics found");
+    }
+
+    @Test
+    void mediumSymbolWarningFromValidationEnginePrintsWithoutBlockingPreCommit(
+            @TempDir Path tempDir) throws Exception {
+        Path file = javaFile(tempDir);
+        CodeCheckCommandService service = createEngineService(file, List.of(
+                diagnostic(file, "Symbol could not be resolved",
+                           ValidationError.Severity.MEDIUM, DiagnosticKind.SYMBOL_WARNING)));
+
+        CommandOutcome outcome = service.runPreCommit();
+
+        assertThat(outcome.exitCode()).isZero();
+        assertThat(output()).contains("Symbol could not be resolved")
+                            .doesNotContain("Blocking HIGH diagnostics found");
+    }
+
+    @Test
+    void batchCheckFailsWhenHighDiagnosticsExist(@TempDir Path tempDir) throws Exception {
+        Path file = javaFile(tempDir);
+        checks.add(alwaysError("Blocking batch issue", ValidationError.Severity.HIGH));
+        CodeCheckCommandService service = createService(() -> Stream.of(file));
+
+        CommandOutcome outcome = service.runBatchCheck();
+
+        assertThat(outcome.exitCode()).isEqualTo(1);
+        assertThat(output()).contains("Blocking batch issue")
+                            .contains("Blocking HIGH diagnostics found");
     }
 
     @Test
@@ -229,6 +285,15 @@ class CodeCheckCommandServiceTest {
                                            new PrintStream(stderr, true, StandardCharsets.UTF_8));
     }
 
+    private CodeCheckCommandService createEngineService(Path file,
+                                                        List<Diagnostic> diagnostics) {
+        return new CodeCheckCommandService(
+                daemonController, pipeline, new FixedValidationEngine(file, diagnostics),
+                new SingleFileChangeSetService(file), CodeCheckConfigLoader.defaultsOnly(),
+                new PrintStream(stdout, true, StandardCharsets.UTF_8),
+                new PrintStream(stderr, true, StandardCharsets.UTF_8));
+    }
+
     private Path javaFile(Path tempDir) throws Exception {
         Path file = tempDir.resolve("Example.java");
         Files.writeString(file, "class Example {}");
@@ -255,6 +320,12 @@ class CodeCheckCommandServiceTest {
 
     private ValidationError error(Path file, String message, ValidationError.Severity severity) {
         return new ValidationError(file, message, new Position(1, 1), severity);
+    }
+
+    private Diagnostic diagnostic(Path file, String message, ValidationError.Severity severity,
+                                  DiagnosticKind kind) {
+        return new Diagnostic(file, message, new SourcePosition(1, 1), severity, kind,
+                              new RuleId("test.rule"));
     }
 
     private String output() {
@@ -295,6 +366,61 @@ class CodeCheckCommandServiceTest {
 
         @Override
         public void applyFix(String diagnosticId) {
+        }
+    }
+
+    private static final class FixedValidationEngine implements ValidationEngine {
+        private final Path file;
+        private final List<Diagnostic> diagnostics;
+
+        private FixedValidationEngine(Path file, List<Diagnostic> diagnostics) {
+            this.file = file;
+            this.diagnostics = diagnostics;
+        }
+
+        @Override
+        public ValidationResult validate(ChangeSet changeSet, ValidationMode mode) {
+            return new ValidationResult(mode, List.of(new FileValidationResult(file, mode,
+                                                                               diagnostics)));
+        }
+
+        @Override
+        public FileValidationResult validateFile(Path file, ValidationMode mode) {
+            return new FileValidationResult(file, mode, diagnostics);
+        }
+    }
+
+    private static final class SingleFileChangeSetService implements ChangeSetService {
+        private final Path file;
+
+        private SingleFileChangeSetService(Path file) {
+            this.file = file;
+        }
+
+        @Override
+        public ChangeSet currentAssistantChangeSet() {
+            return changeSet();
+        }
+
+        @Override
+        public ChangeSet currentInteractiveCheckChangeSet() {
+            return changeSet();
+        }
+
+        @Override
+        public ChangeSet preCommitChangeSet() {
+            return changeSet();
+        }
+
+        @Override
+        public ChangeSet explicitFiles(java.util.Collection<Path> files) {
+            return changeSet();
+        }
+
+        private ChangeSet changeSet() {
+            return new ChangeSet(List.of(new ChangeSetEntry(file, GitFileStatus.MODIFIED,
+                                                            true, false, false, false,
+                                                            "test file")));
         }
     }
 }

--- a/src/test/java/de/zorro909/codecheck/reporting/ModeSeverityPolicyTest.java
+++ b/src/test/java/de/zorro909/codecheck/reporting/ModeSeverityPolicyTest.java
@@ -1,0 +1,42 @@
+package de.zorro909.codecheck.reporting;
+
+import de.zorro909.codecheck.checks.ValidationError;
+import de.zorro909.codecheck.validation.ValidationMode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ModeSeverityPolicyTest {
+
+    private final ModeSeverityPolicy policy = new ModeSeverityPolicy();
+
+    @Test
+    void preCommitHidesLowButShowsMediumAndHigh() {
+        assertThat(policy.visible(ValidationMode.PRE_COMMIT, ValidationError.Severity.LOW))
+                .isFalse();
+        assertThat(policy.visible(ValidationMode.PRE_COMMIT, ValidationError.Severity.MEDIUM))
+                .isTrue();
+        assertThat(policy.visible(ValidationMode.PRE_COMMIT, ValidationError.Severity.HIGH))
+                .isTrue();
+    }
+
+    @Test
+    void preCommitAndBatchOnlyBlockOnHigh() {
+        assertThat(policy.blocks(ValidationMode.PRE_COMMIT, ValidationError.Severity.MEDIUM))
+                .isFalse();
+        assertThat(policy.blocks(ValidationMode.PRE_COMMIT, ValidationError.Severity.HIGH))
+                .isTrue();
+        assertThat(policy.blocks(ValidationMode.BATCH, ValidationError.Severity.LOW))
+                .isFalse();
+        assertThat(policy.blocks(ValidationMode.BATCH, ValidationError.Severity.HIGH))
+                .isTrue();
+    }
+
+    @Test
+    void daemonAndInteractiveShowAllSeverities() {
+        for (ValidationError.Severity severity : ValidationError.Severity.values()) {
+            assertThat(policy.visible(ValidationMode.ASSISTANT, severity)).isTrue();
+            assertThat(policy.visible(ValidationMode.INTERACTIVE, severity)).isTrue();
+        }
+    }
+}

--- a/src/test/java/de/zorro909/codecheck/validation/ValidationResultSeverityStorageTest.java
+++ b/src/test/java/de/zorro909/codecheck/validation/ValidationResultSeverityStorageTest.java
@@ -1,0 +1,33 @@
+package de.zorro909.codecheck.validation;
+
+import de.zorro909.codecheck.checks.ValidationError;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ValidationResultSeverityStorageTest {
+
+    @Test
+    void assistantModeResultRetainsAllSeverities() {
+        Path file = Path.of("Example.java");
+        ValidationResult result = new ValidationResult(ValidationMode.ASSISTANT, List.of(
+                new FileValidationResult(file, ValidationMode.ASSISTANT, List.of(
+                        diagnostic(file, ValidationError.Severity.LOW),
+                        diagnostic(file, ValidationError.Severity.MEDIUM),
+                        diagnostic(file, ValidationError.Severity.HIGH)))));
+
+        assertThat(result.diagnostics()).extracting(Diagnostic::severity)
+                                        .containsExactly(ValidationError.Severity.LOW,
+                                                         ValidationError.Severity.MEDIUM,
+                                                         ValidationError.Severity.HIGH);
+    }
+
+    private Diagnostic diagnostic(Path file, ValidationError.Severity severity) {
+        return new Diagnostic(file, severity + " diagnostic", new SourcePosition(1, 1),
+                              severity, DiagnosticKind.RULE_VIOLATION,
+                              new RuleId("test.rule"));
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit mode/severity visibility and blocking policy
- route terminal diagnostics through a reusable renderer with pre-commit LOW filtering
- add command acceptance tests for parse errors, symbol warnings, pre-commit filtering, and batch blocking

## Tests
- ./mvnw test -Dtest=CodeCheckCommandServiceTest,ModeSeverityPolicyTest,ValidationResultSeverityStorageTest
- ./mvnw test